### PR TITLE
Add build workflow for FarmCtl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+
+      - name: Build
+        run: ./gradlew build


### PR DESCRIPTION
Add a new GitHub Actions workflow to build the FarmCtl project.

* Create a new file `.github/workflows/build.yml`
* Set the workflow to trigger on push and pull request events for the `main` branch
* Define a job named `build` that runs on `ubuntu-latest`
* Add steps to checkout the repository, set up JDK 11, and build the project using `./gradlew build`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ghsi011/FarmCtl?shareId=XXXX-XXXX-XXXX-XXXX).