### PR TITLE
Fix current CI workflows

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -22,19 +22,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ fromJson(steps.request.outputs.data).head.repo.full_name }}
           ref: ${{ steps.pr_data.outputs.branch }}
 
       - name: Setup JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 11
 
       - name: Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/${{ env.WORKING_DIR }}/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -11,15 +11,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Setup JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 11
 
       - name: Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/${{ env.WORKING_DIR }}/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}

--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -11,15 +11,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Setup JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 11
 
       - name: Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/${{ env.WORKING_DIR }}/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,15 +11,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Setup JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 11
 
       - name: Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/${{ env.WORKING_DIR }}/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,15 +11,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Setup JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 11
 
       - name: Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/${{ env.WORKING_DIR }}/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}


### PR DESCRIPTION
Update CI workflows to use newer versions of GitHub Actions.

* **dependencies.yml**
  - Update `actions/checkout` to v2
  - Update `actions/setup-java` to v2
  - Update `actions/cache` to v2

* **detekt.yml**
  - Update `actions/checkout` to v2
  - Update `actions/setup-java` to v2
  - Update `actions/cache` to v2

* **ktlint.yml**
  - Update `actions/checkout` to v2
  - Update `actions/setup-java` to v2
  - Update `actions/cache` to v2

* **lint.yml**
  - Update `actions/checkout` to v2
  - Update `actions/setup-java` to v2
  - Update `actions/cache` to v2

* **test.yml**
  - Update `actions/checkout` to v2
  - Update `actions/setup-java` to v2
  - Update `actions/cache` to v2

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ghsi011/FarmCtl?shareId=XXXX-XXXX-XXXX-XXXX).