### PR TITLE
Bootstrap Flutter workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.tooling/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
 # FarmCtl
 
-# Spec.md describes the app and its functions
+FarmCtl is a smart-thermostat monitoring client targeting Android. The Flutter workspace is located in [`app/`](app/).
+
+## Getting Started
+
+### Prerequisites
+1. [Install Flutter](https://docs.flutter.dev/get-started/install) (3.16 or newer recommended).
+2. Enable Android toolchain support and accept the Android SDK licenses.
+3. Start an Android emulator or connect a device with developer mode enabled.
+
+### Running the App
+```bash
+cd app
+flutter pub get
+flutter run
+```
+
+The application launches with Material 3 theming, Riverpod-provided state management, and a bottom navigation bar exposing the Thermostats and Settings tabs. The Thermostats tab shows a static thermostat card that will be replaced with live data in future iterations.
+
+### Project Structure Highlights
+- `lib/` — Flutter source code organised by feature, including navigation (`core/router`) and feature modules (`features/thermostats`, `features/settings`).
+- `pubspec.yaml` — Dependency manifest including Riverpod, GoRouter, Freezed annotations, Dio, and Drift for future iterations.
+- `test/` — Placeholder widget test scaffolding for future coverage.
+
+Refer to [`Spec.md`](Spec.md) and [`docs/ImplementationPlan.md`](docs/ImplementationPlan.md) for the product roadmap and architectural guidance.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,22 @@ FarmCtl is a smart-thermostat monitoring client targeting Android. The Flutter w
 ## Getting Started
 
 ### Prerequisites
-1. [Install Flutter](https://docs.flutter.dev/get-started/install) (3.16 or newer recommended).
-2. Enable Android toolchain support and accept the Android SDK licenses.
-3. Start an Android emulator or connect a device with developer mode enabled.
+You can either install Flutter globally or use the repository-managed SDK bootstrap described below.
+
+1. Enable Android toolchain support and accept the Android SDK licenses.
+2. Start an Android emulator or connect a device with developer mode enabled.
+
+#### Repository-managed Flutter SDK
+
+The repository includes helper scripts that download the Flutter SDK into `.tooling/flutter` and expose a shell environment with the correct `PATH`.
+
+```bash
+./tool/setup_flutter.sh          # downloads/updates the SDK
+source ./tool/flutter_env.sh     # adds flutter and dart to PATH for the current shell
+flutter doctor                   # optional health check
+```
+
+You can add `source /path/to/repo/tool/flutter_env.sh` to your shell profile if you want the SDK available automatically whenever you work on FarmCtl.
 
 ### Running the App
 ```bash

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,0 +1,34 @@
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.packages
+.pub-cache/
+.pub/
+build/
+flutter_*.png
+linked_*\.ds
+unlinked_*.ds
+dartdoc_options.yaml
+
+# Android
+**/android/app/debug
+**/android/app/profile
+**/android/app/release
+**/android/local.properties
+**/android/.gradle
+**/android/captures
+**/android/gradlew*
+**/android/gradle/
+
+# iOS/macOS
+**/ios/Flutter/Generated.xcconfig
+**/ios/Pods/
+**/ios/Runner/GeneratedPluginRegistrant.*
+**/macos/Flutter/GeneratedPluginRegistrant.*
+
+# Web
+**/web/generated_plugin_registrant.dart
+
+# Exceptions to the ignore rules
+!**/ios/.gitkeep
+!**/macos/.gitkeep

--- a/app/.metadata
+++ b/app/.metadata
@@ -1,0 +1,6 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to determine if directory is created.
+version:
+  revision: 0000000000000000000000000000000000000000
+  channel: stable
+project_type: app

--- a/app/analysis_options.yaml
+++ b/app/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    prefer_single_quotes: true

--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'core/router/app_router.dart';
+
+class FarmCtlApp extends ConsumerWidget {
+  const FarmCtlApp({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final router = ref.watch(appRouterProvider);
+    final colorScheme = ColorScheme.fromSeed(seedColor: const Color(0xFF4CAF50));
+
+    return MaterialApp.router(
+      title: 'FarmCtl',
+      theme: ThemeData(
+        colorScheme: colorScheme,
+        useMaterial3: true,
+        appBarTheme: AppBarTheme(backgroundColor: colorScheme.surface),
+      ),
+      routerConfig: router,
+    );
+  }
+}

--- a/app/lib/core/router/app_router.dart
+++ b/app/lib/core/router/app_router.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../features/settings/view/settings_page.dart';
+import '../../features/thermostats/view/thermostats_page.dart';
+
+final _rootNavigatorKey = GlobalKey<NavigatorState>();
+
+final appRouterProvider = Provider<GoRouter>((ref) {
+  return GoRouter(
+    navigatorKey: _rootNavigatorKey,
+    initialLocation: ThermostatsRoute.path,
+    routes: [
+      StatefulShellRoute.indexedStack(
+        builder: (context, state, navigationShell) {
+          return AppScaffold(navigationShell: navigationShell);
+        },
+        branches: [
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: ThermostatsRoute.path,
+                name: ThermostatsRoute.name,
+                pageBuilder: (context, state) => const NoTransitionPage(
+                  child: ThermostatsPage(),
+                ),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: SettingsRoute.path,
+                name: SettingsRoute.name,
+                pageBuilder: (context, state) => const NoTransitionPage(
+                  child: SettingsPage(),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    ],
+  );
+});
+
+class AppScaffold extends StatelessWidget {
+  const AppScaffold({
+    required this.navigationShell,
+    super.key,
+  });
+
+  final StatefulNavigationShell navigationShell;
+
+  void _goBranch(int index) {
+    navigationShell.goBranch(index, initialLocation: index == navigationShell.currentIndex);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: navigationShell,
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: navigationShell.currentIndex,
+        destinations: const [
+          NavigationDestination(
+            icon: Icon(Icons.thermostat),
+            label: 'Thermostats',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.settings),
+            label: 'Settings',
+          ),
+        ],
+        onDestinationSelected: _goBranch,
+      ),
+    );
+  }
+}
+
+class ThermostatsRoute {
+  static const name = 'thermostats';
+  static const path = '/thermostats';
+}
+
+class SettingsRoute {
+  static const name = 'settings';
+  static const path = '/settings';
+}

--- a/app/lib/features/settings/view/settings_page.dart
+++ b/app/lib/features/settings/view/settings_page.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class SettingsPage extends StatelessWidget {
+  const SettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Settings'),
+      ),
+      body: Center(
+        child: Text(
+          'Settings coming soon',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/thermostats/view/thermostats_page.dart
+++ b/app/lib/features/thermostats/view/thermostats_page.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+import '../widgets/thermostat_card.dart';
+
+class ThermostatsPage extends StatelessWidget {
+  const ThermostatsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Thermostats'),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: const [
+          ThermostatCard(
+            name: 'Main Barn',
+            temperature: '68°F',
+            lastUpdated: 'Updated 5 minutes ago',
+            status: ThermostatStatus.normal,
+          ),
+          SizedBox(height: 12),
+          ThermostatCard(
+            name: 'Propagation Greenhouse',
+            temperature: '72°F',
+            lastUpdated: 'Updated 10 minutes ago',
+            status: ThermostatStatus.warning,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/features/thermostats/widgets/thermostat_card.dart
+++ b/app/lib/features/thermostats/widgets/thermostat_card.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+
+enum ThermostatStatus { normal, warning, critical }
+
+class ThermostatCard extends StatelessWidget {
+  const ThermostatCard({
+    required this.name,
+    required this.temperature,
+    required this.lastUpdated,
+    this.status = ThermostatStatus.normal,
+    super.key,
+  });
+
+  final String name;
+  final String temperature;
+  final String lastUpdated;
+  final ThermostatStatus status;
+
+  Color _statusColor(ColorScheme colorScheme) {
+    switch (status) {
+      case ThermostatStatus.normal:
+        return colorScheme.primary;
+      case ThermostatStatus.warning:
+        return colorScheme.tertiary;
+      case ThermostatStatus.critical:
+        return colorScheme.error;
+    }
+  }
+
+  IconData _statusIcon() {
+    switch (status) {
+      case ThermostatStatus.normal:
+        return Icons.check_circle;
+      case ThermostatStatus.warning:
+        return Icons.error_outline;
+      case ThermostatStatus.critical:
+        return Icons.warning_amber;
+    }
+  }
+
+  String _statusLabel() {
+    switch (status) {
+      case ThermostatStatus.normal:
+        return 'Within range';
+      case ThermostatStatus.warning:
+        return 'Check soon';
+      case ThermostatStatus.critical:
+        return 'Out of range';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final textTheme = theme.textTheme;
+
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(name, style: textTheme.titleLarge),
+            const SizedBox(height: 12),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(Icons.thermostat, size: 36, color: colorScheme.primary),
+                const SizedBox(width: 12),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      temperature,
+                      style: textTheme.headlineMedium?.copyWith(fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      lastUpdated,
+                      style: textTheme.bodyMedium?.copyWith(color: colorScheme.outline),
+                    ),
+                  ],
+                ),
+                const Spacer(),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Icon(_statusIcon(), color: _statusColor(colorScheme)),
+                    const SizedBox(height: 4),
+                    Text(
+                      _statusLabel(),
+                      style: textTheme.bodyMedium?.copyWith(
+                        color: _statusColor(colorScheme),
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'app.dart';
+
+void main() {
+  runApp(const ProviderScope(child: FarmCtlApp()));
+}

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -1,0 +1,26 @@
+name: farmctl
+description: Smart thermostat monitoring client.
+publish_to: 'none'
+version: 0.1.0+1
+
+environment:
+  sdk: '>=3.2.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_riverpod: ^2.4.10
+  go_router: ^13.2.1
+  freezed_annotation: ^2.4.1
+  dio: ^5.4.0
+  drift: ^2.14.1
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.1
+  build_runner: ^2.4.8
+  freezed: ^2.4.7
+
+flutter:
+  uses-material-design: true

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -1,0 +1,18 @@
+import 'package:farmctl/app.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('FarmCtl renders bottom navigation', (tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: FarmCtlApp(),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Thermostats'), findsWidgets);
+    expect(find.text('Settings'), findsWidgets);
+  });
+}

--- a/tool/flutter_env.sh
+++ b/tool/flutter_env.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1090,SC1091
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export FLUTTER_ROOT="${FLUTTER_ROOT:-${REPO_ROOT}/.tooling/flutter}"
+export PATH="${FLUTTER_ROOT}/bin:${PATH}"

--- a/tool/setup_flutter.sh
+++ b/tool/setup_flutter.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine repository root
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FLUTTER_DIR="${FLUTTER_DIR:-${REPO_ROOT}/.tooling/flutter}"
+FLUTTER_CHANNEL="${FLUTTER_CHANNEL:-stable}"
+FLUTTER_VERSION="${FLUTTER_VERSION:-}"
+
+mkdir -p "$(dirname "${FLUTTER_DIR}")"
+
+if [ ! -d "${FLUTTER_DIR}" ]; then
+  echo "Cloning Flutter SDK (${FLUTTER_CHANNEL}) into ${FLUTTER_DIR}" >&2
+  git clone --depth 1 --branch "${FLUTTER_CHANNEL}" https://github.com/flutter/flutter.git "${FLUTTER_DIR}"
+else
+  echo "Updating existing Flutter SDK in ${FLUTTER_DIR}" >&2
+  git -C "${FLUTTER_DIR}" fetch --depth 1 origin "${FLUTTER_CHANNEL}"
+  git -C "${FLUTTER_DIR}" reset --hard FETCH_HEAD
+fi
+
+if [ -n "${FLUTTER_VERSION}" ]; then
+  echo "Checking out Flutter version ${FLUTTER_VERSION}" >&2
+  git -C "${FLUTTER_DIR}" fetch --depth 1 origin "refs/tags/${FLUTTER_VERSION}" || true
+  if git -C "${FLUTTER_DIR}" rev-parse "${FLUTTER_VERSION}" >/dev/null 2>&1; then
+    git -C "${FLUTTER_DIR}" checkout "${FLUTTER_VERSION}"
+  else
+    echo "Requested FLUTTER_VERSION ${FLUTTER_VERSION} was not found. Remaining on ${FLUTTER_CHANNEL}." >&2
+  fi
+fi
+
+"${FLUTTER_DIR}/bin/flutter" --version


### PR DESCRIPTION
## Summary
- add a Flutter workspace under `app/` configured with Material 3 theming, Riverpod, and GoRouter navigation scaffolding
- implement baseline Thermostats and Settings tabs with a static thermostat card component for iteration 1
- document Flutter tooling prerequisites and run instructions in the root README

## Testing
- not run (Flutter tooling is not available in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_68ea3d4645b08325ae553c38db9d63c5