### PR TITLE
Implement Test & Save flow with thermostat state tracking

### DIFF
--- a/app/lib/features/thermostats/data/thermostat_client.dart
+++ b/app/lib/features/thermostats/data/thermostat_client.dart
@@ -1,0 +1,145 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:dio_smart_retry/dio_smart_retry.dart';
+import 'package:farmctl_parsing/temperature_parser.dart';
+
+import '../models/thermostat_state.dart';
+
+abstract class ThermostatNetworkDataSource {
+  Future<ThermostatFetchSuccess> fetchCurrent(String url);
+}
+
+class ThermostatHttpClient implements ThermostatNetworkDataSource {
+  ThermostatHttpClient({Dio? dio}) : _dio = dio ?? _createDio();
+
+  final Dio _dio;
+
+  static Dio _createDio() {
+    final dio = Dio(
+      BaseOptions(
+        connectTimeout: const Duration(seconds: 5),
+        receiveTimeout: const Duration(seconds: 10),
+        sendTimeout: const Duration(seconds: 10),
+      ),
+    );
+    dio.interceptors.add(
+      RetryInterceptor(
+        dio: dio,
+        logPrint: (_) {},
+        retries: 2,
+        retryDelays: const [Duration(seconds: 1), Duration(seconds: 3)],
+        retryEvaluator: (error, attempt) {
+          if (error.type == DioExceptionType.badResponse) {
+            final status = error.response?.statusCode ?? 0;
+            return status >= 500 && status < 600;
+          }
+          return error.type == DioExceptionType.connectionTimeout ||
+              error.type == DioExceptionType.sendTimeout ||
+              error.type == DioExceptionType.receiveTimeout ||
+              error.type == DioExceptionType.connectionError ||
+              error.type == DioExceptionType.unknown;
+        },
+      ),
+    );
+    return dio;
+  }
+
+  @override
+  Future<ThermostatFetchSuccess> fetchCurrent(String url) async {
+    try {
+      final response = await _dio.get<String>(
+        url,
+        options: Options(
+          responseType: ResponseType.plain,
+          headers: const {HttpHeaders.acceptHeader: 'text/plain'},
+        ),
+      );
+
+      final statusCode = response.statusCode ?? 0;
+      if (statusCode != 200) {
+        throw ThermostatFetchException(
+          status: ThermostatReadingStatus.httpError,
+          statusCode: statusCode,
+          message: 'Request failed with status $statusCode.',
+        );
+      }
+
+      final body = response.data ?? '';
+      final value = parseCelsiusTemperature(body);
+      if (value == null) {
+        throw ThermostatFetchException(
+          status: ThermostatReadingStatus.parseError,
+          message: 'Response did not include a Celsius temperature.',
+        );
+      }
+
+      final fetchedAt = DateTime.now().toUtc();
+      final etag = response.headers.value(HttpHeaders.etagHeader);
+      return ThermostatFetchSuccess(
+        valueC: value,
+        fetchedAt: fetchedAt,
+        etag: etag,
+      );
+    } on ThermostatFetchException {
+      rethrow;
+    } on DioException catch (error) {
+      if (error.type == DioExceptionType.badResponse) {
+        final statusCode = error.response?.statusCode ?? 0;
+        throw ThermostatFetchException(
+          status: ThermostatReadingStatus.httpError,
+          statusCode: statusCode,
+          message: 'Request failed with status $statusCode.',
+          cause: error,
+        );
+      }
+      final isTimeout =
+          error.type == DioExceptionType.connectionTimeout ||
+          error.type == DioExceptionType.sendTimeout ||
+          error.type == DioExceptionType.receiveTimeout;
+      throw ThermostatFetchException(
+        status: ThermostatReadingStatus.networkError,
+        message: isTimeout
+            ? 'Request timed out. Check the URL and try again.'
+            : 'Failed to reach the thermostat source.',
+        cause: error,
+      );
+    } catch (error) {
+      throw ThermostatFetchException(
+        status: ThermostatReadingStatus.networkError,
+        message: 'Failed to fetch thermostat data.',
+        cause: error,
+      );
+    }
+  }
+}
+
+class ThermostatFetchSuccess {
+  const ThermostatFetchSuccess({
+    required this.valueC,
+    required this.fetchedAt,
+    this.etag,
+  });
+
+  final double valueC;
+  final DateTime fetchedAt;
+  final String? etag;
+}
+
+class ThermostatFetchException implements Exception {
+  const ThermostatFetchException({
+    required this.status,
+    required this.message,
+    this.statusCode,
+    this.cause,
+  });
+
+  final ThermostatReadingStatus status;
+  final String message;
+  final int? statusCode;
+  final Object? cause;
+
+  @override
+  String toString() =>
+      'ThermostatFetchException(status: ${status.name}, message: $message, statusCode: $statusCode)';
+}

--- a/app/lib/features/thermostats/data/thermostat_database.dart
+++ b/app/lib/features/thermostats/data/thermostat_database.dart
@@ -32,6 +32,25 @@ class ThermostatEntries extends Table {
   Set<Column<Object>> get primaryKey => {id};
 }
 
+class ThermostatStateEntries extends Table {
+  TextColumn get thermostatId => text()();
+
+  RealColumn get lastValueC => real().nullable()();
+
+  TextColumn get lastStatus => text().nullable()();
+
+  DateTimeColumn get lastFetchedAt => dateTime().nullable()();
+
+  TextColumn get etag => text().nullable()();
+
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+
+  DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
+
+  @override
+  Set<Column<Object>> get primaryKey => {thermostatId};
+}
+
 class AlertConfigEntries extends Table {
   IntColumn get id => integer().autoIncrement()();
 
@@ -57,7 +76,14 @@ LazyDatabase _openConnection() {
   });
 }
 
-@DriftDatabase(tables: [ThermostatEntries, AlertConfigEntries])
+typedef ThermostatWithStateRow = ({
+  ThermostatEntry thermostat,
+  ThermostatStateEntry? state,
+});
+
+@DriftDatabase(
+  tables: [ThermostatEntries, AlertConfigEntries, ThermostatStateEntries],
+)
 class ThermostatDatabase extends _$ThermostatDatabase {
   ThermostatDatabase() : super(_openConnection());
 
@@ -72,10 +98,44 @@ class ThermostatDatabase extends _$ThermostatDatabase {
     )..orderBy([(tbl) => OrderingTerm.asc(tbl.name)])).get();
   }
 
-  Stream<List<ThermostatEntry>> watchThermostats() {
-    return (select(
-      thermostatEntries,
-    )..orderBy([(tbl) => OrderingTerm.asc(tbl.name)])).watch();
+  Future<List<ThermostatWithStateRow>> listThermostatsWithState() {
+    final query = select(thermostatEntries).join([
+      leftOuterJoin(
+        thermostatStateEntries,
+        thermostatStateEntries.thermostatId.equalsExp(thermostatEntries.id),
+      ),
+    ])..orderBy([OrderingTerm.asc(thermostatEntries.name)]);
+
+    return query.get().then(
+      (rows) => rows
+          .map(
+            (row) => (
+              thermostat: row.readTable(thermostatEntries),
+              state: row.readTableOrNull(thermostatStateEntries),
+            ),
+          )
+          .toList(),
+    );
+  }
+
+  Stream<List<ThermostatWithStateRow>> watchThermostatsWithState() {
+    final query = select(thermostatEntries).join([
+      leftOuterJoin(
+        thermostatStateEntries,
+        thermostatStateEntries.thermostatId.equalsExp(thermostatEntries.id),
+      ),
+    ])..orderBy([OrderingTerm.asc(thermostatEntries.name)]);
+
+    return query.watch().map(
+      (rows) => rows
+          .map(
+            (row) => (
+              thermostat: row.readTable(thermostatEntries),
+              state: row.readTableOrNull(thermostatStateEntries),
+            ),
+          )
+          .toList(),
+    );
   }
 
   Future<ThermostatEntry?> getThermostat(String id) {
@@ -84,11 +144,29 @@ class ThermostatDatabase extends _$ThermostatDatabase {
     )..where((tbl) => tbl.id.equals(id))).getSingleOrNull();
   }
 
+  Future<ThermostatStateEntry?> getThermostatState(String id) {
+    return (select(
+      thermostatStateEntries,
+    )..where((tbl) => tbl.thermostatId.equals(id))).getSingleOrNull();
+  }
+
   Future<void> upsertThermostat(ThermostatEntriesCompanion data) async {
     await into(thermostatEntries).insertOnConflictUpdate(data);
   }
 
+  Future<void> upsertThermostatState(
+    ThermostatStateEntriesCompanion data,
+  ) async {
+    await into(thermostatStateEntries).insertOnConflictUpdate(data);
+  }
+
   Future<void> deleteThermostatById(String id) async {
     await (delete(thermostatEntries)..where((tbl) => tbl.id.equals(id))).go();
+  }
+
+  Future<void> deleteThermostatStateById(String id) async {
+    await (delete(
+      thermostatStateEntries,
+    )..where((tbl) => tbl.thermostatId.equals(id))).go();
   }
 }

--- a/app/lib/features/thermostats/data/thermostat_database.g.dart
+++ b/app/lib/features/thermostats/data/thermostat_database.g.dart
@@ -1049,6 +1049,493 @@ class AlertConfigEntriesCompanion extends UpdateCompanion<AlertConfigEntry> {
   }
 }
 
+class $ThermostatStateEntriesTable extends ThermostatStateEntries
+    with TableInfo<$ThermostatStateEntriesTable, ThermostatStateEntry> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $ThermostatStateEntriesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _thermostatIdMeta = const VerificationMeta(
+    'thermostatId',
+  );
+  @override
+  late final GeneratedColumn<String> thermostatId = GeneratedColumn<String>(
+    'thermostat_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _lastValueCMeta = const VerificationMeta(
+    'lastValueC',
+  );
+  @override
+  late final GeneratedColumn<double> lastValueC = GeneratedColumn<double>(
+    'last_value_c',
+    aliasedName,
+    true,
+    type: DriftSqlType.double,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _lastStatusMeta = const VerificationMeta(
+    'lastStatus',
+  );
+  @override
+  late final GeneratedColumn<String> lastStatus = GeneratedColumn<String>(
+    'last_status',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _lastFetchedAtMeta = const VerificationMeta(
+    'lastFetchedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> lastFetchedAt =
+      GeneratedColumn<DateTime>(
+        'last_fetched_at',
+        aliasedName,
+        true,
+        type: DriftSqlType.dateTime,
+        requiredDuringInsert: false,
+      );
+  static const VerificationMeta _etagMeta = const VerificationMeta('etag');
+  @override
+  late final GeneratedColumn<String> etag = GeneratedColumn<String>(
+    'etag',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
+    'updatedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
+    'updated_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    thermostatId,
+    lastValueC,
+    lastStatus,
+    lastFetchedAt,
+    etag,
+    createdAt,
+    updatedAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'thermostat_state_entries';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<ThermostatStateEntry> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('thermostat_id')) {
+      context.handle(
+        _thermostatIdMeta,
+        thermostatId.isAcceptableOrUnknown(
+          data['thermostat_id']!,
+          _thermostatIdMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_thermostatIdMeta);
+    }
+    if (data.containsKey('last_value_c')) {
+      context.handle(
+        _lastValueCMeta,
+        lastValueC.isAcceptableOrUnknown(
+          data['last_value_c']!,
+          _lastValueCMeta,
+        ),
+      );
+    }
+    if (data.containsKey('last_status')) {
+      context.handle(
+        _lastStatusMeta,
+        lastStatus.isAcceptableOrUnknown(data['last_status']!, _lastStatusMeta),
+      );
+    }
+    if (data.containsKey('last_fetched_at')) {
+      context.handle(
+        _lastFetchedAtMeta,
+        lastFetchedAt.isAcceptableOrUnknown(
+          data['last_fetched_at']!,
+          _lastFetchedAtMeta,
+        ),
+      );
+    }
+    if (data.containsKey('etag')) {
+      context.handle(
+        _etagMeta,
+        etag.isAcceptableOrUnknown(data['etag']!, _etagMeta),
+      );
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(
+        _updatedAtMeta,
+        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {thermostatId};
+  @override
+  ThermostatStateEntry map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return ThermostatStateEntry(
+      thermostatId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}thermostat_id'],
+      )!,
+      lastValueC: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}last_value_c'],
+      ),
+      lastStatus: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}last_status'],
+      ),
+      lastFetchedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}last_fetched_at'],
+      ),
+      etag: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}etag'],
+      ),
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}updated_at'],
+      )!,
+    );
+  }
+
+  @override
+  $ThermostatStateEntriesTable createAlias(String alias) {
+    return $ThermostatStateEntriesTable(attachedDatabase, alias);
+  }
+}
+
+class ThermostatStateEntry extends DataClass
+    implements Insertable<ThermostatStateEntry> {
+  final String thermostatId;
+  final double? lastValueC;
+  final String? lastStatus;
+  final DateTime? lastFetchedAt;
+  final String? etag;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  const ThermostatStateEntry({
+    required this.thermostatId,
+    this.lastValueC,
+    this.lastStatus,
+    this.lastFetchedAt,
+    this.etag,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['thermostat_id'] = Variable<String>(thermostatId);
+    if (!nullToAbsent || lastValueC != null) {
+      map['last_value_c'] = Variable<double>(lastValueC);
+    }
+    if (!nullToAbsent || lastStatus != null) {
+      map['last_status'] = Variable<String>(lastStatus);
+    }
+    if (!nullToAbsent || lastFetchedAt != null) {
+      map['last_fetched_at'] = Variable<DateTime>(lastFetchedAt);
+    }
+    if (!nullToAbsent || etag != null) {
+      map['etag'] = Variable<String>(etag);
+    }
+    map['created_at'] = Variable<DateTime>(createdAt);
+    map['updated_at'] = Variable<DateTime>(updatedAt);
+    return map;
+  }
+
+  ThermostatStateEntriesCompanion toCompanion(bool nullToAbsent) {
+    return ThermostatStateEntriesCompanion(
+      thermostatId: Value(thermostatId),
+      lastValueC: lastValueC == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lastValueC),
+      lastStatus: lastStatus == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lastStatus),
+      lastFetchedAt: lastFetchedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lastFetchedAt),
+      etag: etag == null && nullToAbsent ? const Value.absent() : Value(etag),
+      createdAt: Value(createdAt),
+      updatedAt: Value(updatedAt),
+    );
+  }
+
+  factory ThermostatStateEntry.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return ThermostatStateEntry(
+      thermostatId: serializer.fromJson<String>(json['thermostatId']),
+      lastValueC: serializer.fromJson<double?>(json['lastValueC']),
+      lastStatus: serializer.fromJson<String?>(json['lastStatus']),
+      lastFetchedAt: serializer.fromJson<DateTime?>(json['lastFetchedAt']),
+      etag: serializer.fromJson<String?>(json['etag']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'thermostatId': serializer.toJson<String>(thermostatId),
+      'lastValueC': serializer.toJson<double?>(lastValueC),
+      'lastStatus': serializer.toJson<String?>(lastStatus),
+      'lastFetchedAt': serializer.toJson<DateTime?>(lastFetchedAt),
+      'etag': serializer.toJson<String?>(etag),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+      'updatedAt': serializer.toJson<DateTime>(updatedAt),
+    };
+  }
+
+  ThermostatStateEntry copyWith({
+    String? thermostatId,
+    Value<double?> lastValueC = const Value.absent(),
+    Value<String?> lastStatus = const Value.absent(),
+    Value<DateTime?> lastFetchedAt = const Value.absent(),
+    Value<String?> etag = const Value.absent(),
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) => ThermostatStateEntry(
+    thermostatId: thermostatId ?? this.thermostatId,
+    lastValueC: lastValueC.present ? lastValueC.value : this.lastValueC,
+    lastStatus: lastStatus.present ? lastStatus.value : this.lastStatus,
+    lastFetchedAt: lastFetchedAt.present
+        ? lastFetchedAt.value
+        : this.lastFetchedAt,
+    etag: etag.present ? etag.value : this.etag,
+    createdAt: createdAt ?? this.createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+  );
+  ThermostatStateEntry copyWithCompanion(ThermostatStateEntriesCompanion data) {
+    return ThermostatStateEntry(
+      thermostatId: data.thermostatId.present
+          ? data.thermostatId.value
+          : this.thermostatId,
+      lastValueC: data.lastValueC.present
+          ? data.lastValueC.value
+          : this.lastValueC,
+      lastStatus: data.lastStatus.present
+          ? data.lastStatus.value
+          : this.lastStatus,
+      lastFetchedAt: data.lastFetchedAt.present
+          ? data.lastFetchedAt.value
+          : this.lastFetchedAt,
+      etag: data.etag.present ? data.etag.value : this.etag,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ThermostatStateEntry(')
+          ..write('thermostatId: $thermostatId, ')
+          ..write('lastValueC: $lastValueC, ')
+          ..write('lastStatus: $lastStatus, ')
+          ..write('lastFetchedAt: $lastFetchedAt, ')
+          ..write('etag: $etag, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    thermostatId,
+    lastValueC,
+    lastStatus,
+    lastFetchedAt,
+    etag,
+    createdAt,
+    updatedAt,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is ThermostatStateEntry &&
+          other.thermostatId == this.thermostatId &&
+          other.lastValueC == this.lastValueC &&
+          other.lastStatus == this.lastStatus &&
+          other.lastFetchedAt == this.lastFetchedAt &&
+          other.etag == this.etag &&
+          other.createdAt == this.createdAt &&
+          other.updatedAt == this.updatedAt);
+}
+
+class ThermostatStateEntriesCompanion
+    extends UpdateCompanion<ThermostatStateEntry> {
+  final Value<String> thermostatId;
+  final Value<double?> lastValueC;
+  final Value<String?> lastStatus;
+  final Value<DateTime?> lastFetchedAt;
+  final Value<String?> etag;
+  final Value<DateTime> createdAt;
+  final Value<DateTime> updatedAt;
+  final Value<int> rowid;
+  const ThermostatStateEntriesCompanion({
+    this.thermostatId = const Value.absent(),
+    this.lastValueC = const Value.absent(),
+    this.lastStatus = const Value.absent(),
+    this.lastFetchedAt = const Value.absent(),
+    this.etag = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  ThermostatStateEntriesCompanion.insert({
+    required String thermostatId,
+    this.lastValueC = const Value.absent(),
+    this.lastStatus = const Value.absent(),
+    this.lastFetchedAt = const Value.absent(),
+    this.etag = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : thermostatId = Value(thermostatId);
+  static Insertable<ThermostatStateEntry> custom({
+    Expression<String>? thermostatId,
+    Expression<double>? lastValueC,
+    Expression<String>? lastStatus,
+    Expression<DateTime>? lastFetchedAt,
+    Expression<String>? etag,
+    Expression<DateTime>? createdAt,
+    Expression<DateTime>? updatedAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (thermostatId != null) 'thermostat_id': thermostatId,
+      if (lastValueC != null) 'last_value_c': lastValueC,
+      if (lastStatus != null) 'last_status': lastStatus,
+      if (lastFetchedAt != null) 'last_fetched_at': lastFetchedAt,
+      if (etag != null) 'etag': etag,
+      if (createdAt != null) 'created_at': createdAt,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  ThermostatStateEntriesCompanion copyWith({
+    Value<String>? thermostatId,
+    Value<double?>? lastValueC,
+    Value<String?>? lastStatus,
+    Value<DateTime?>? lastFetchedAt,
+    Value<String?>? etag,
+    Value<DateTime>? createdAt,
+    Value<DateTime>? updatedAt,
+    Value<int>? rowid,
+  }) {
+    return ThermostatStateEntriesCompanion(
+      thermostatId: thermostatId ?? this.thermostatId,
+      lastValueC: lastValueC ?? this.lastValueC,
+      lastStatus: lastStatus ?? this.lastStatus,
+      lastFetchedAt: lastFetchedAt ?? this.lastFetchedAt,
+      etag: etag ?? this.etag,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (thermostatId.present) {
+      map['thermostat_id'] = Variable<String>(thermostatId.value);
+    }
+    if (lastValueC.present) {
+      map['last_value_c'] = Variable<double>(lastValueC.value);
+    }
+    if (lastStatus.present) {
+      map['last_status'] = Variable<String>(lastStatus.value);
+    }
+    if (lastFetchedAt.present) {
+      map['last_fetched_at'] = Variable<DateTime>(lastFetchedAt.value);
+    }
+    if (etag.present) {
+      map['etag'] = Variable<String>(etag.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<DateTime>(updatedAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ThermostatStateEntriesCompanion(')
+          ..write('thermostatId: $thermostatId, ')
+          ..write('lastValueC: $lastValueC, ')
+          ..write('lastStatus: $lastStatus, ')
+          ..write('lastFetchedAt: $lastFetchedAt, ')
+          ..write('etag: $etag, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$ThermostatDatabase extends GeneratedDatabase {
   _$ThermostatDatabase(QueryExecutor e) : super(e);
   $ThermostatDatabaseManager get managers => $ThermostatDatabaseManager(this);
@@ -1056,6 +1543,8 @@ abstract class _$ThermostatDatabase extends GeneratedDatabase {
       $ThermostatEntriesTable(this);
   late final $AlertConfigEntriesTable alertConfigEntries =
       $AlertConfigEntriesTable(this);
+  late final $ThermostatStateEntriesTable thermostatStateEntries =
+      $ThermostatStateEntriesTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -1063,6 +1552,7 @@ abstract class _$ThermostatDatabase extends GeneratedDatabase {
   List<DatabaseSchemaEntity> get allSchemaEntities => [
     thermostatEntries,
     alertConfigEntries,
+    thermostatStateEntries,
   ];
 }
 
@@ -1612,6 +2102,271 @@ typedef $$AlertConfigEntriesTableProcessedTableManager =
       AlertConfigEntry,
       PrefetchHooks Function()
     >;
+typedef $$ThermostatStateEntriesTableCreateCompanionBuilder =
+    ThermostatStateEntriesCompanion Function({
+      required String thermostatId,
+      Value<double?> lastValueC,
+      Value<String?> lastStatus,
+      Value<DateTime?> lastFetchedAt,
+      Value<String?> etag,
+      Value<DateTime> createdAt,
+      Value<DateTime> updatedAt,
+      Value<int> rowid,
+    });
+typedef $$ThermostatStateEntriesTableUpdateCompanionBuilder =
+    ThermostatStateEntriesCompanion Function({
+      Value<String> thermostatId,
+      Value<double?> lastValueC,
+      Value<String?> lastStatus,
+      Value<DateTime?> lastFetchedAt,
+      Value<String?> etag,
+      Value<DateTime> createdAt,
+      Value<DateTime> updatedAt,
+      Value<int> rowid,
+    });
+
+class $$ThermostatStateEntriesTableFilterComposer
+    extends Composer<_$ThermostatDatabase, $ThermostatStateEntriesTable> {
+  $$ThermostatStateEntriesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get thermostatId => $composableBuilder(
+    column: $table.thermostatId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get lastValueC => $composableBuilder(
+    column: $table.lastValueC,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get lastStatus => $composableBuilder(
+    column: $table.lastStatus,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get lastFetchedAt => $composableBuilder(
+    column: $table.lastFetchedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get etag => $composableBuilder(
+    column: $table.etag,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$ThermostatStateEntriesTableOrderingComposer
+    extends Composer<_$ThermostatDatabase, $ThermostatStateEntriesTable> {
+  $$ThermostatStateEntriesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get thermostatId => $composableBuilder(
+    column: $table.thermostatId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get lastValueC => $composableBuilder(
+    column: $table.lastValueC,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get lastStatus => $composableBuilder(
+    column: $table.lastStatus,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get lastFetchedAt => $composableBuilder(
+    column: $table.lastFetchedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get etag => $composableBuilder(
+    column: $table.etag,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$ThermostatStateEntriesTableAnnotationComposer
+    extends Composer<_$ThermostatDatabase, $ThermostatStateEntriesTable> {
+  $$ThermostatStateEntriesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get thermostatId => $composableBuilder(
+    column: $table.thermostatId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<double> get lastValueC => $composableBuilder(
+    column: $table.lastValueC,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get lastStatus => $composableBuilder(
+    column: $table.lastStatus,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get lastFetchedAt => $composableBuilder(
+    column: $table.lastFetchedAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get etag =>
+      $composableBuilder(column: $table.etag, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+}
+
+class $$ThermostatStateEntriesTableTableManager
+    extends
+        RootTableManager<
+          _$ThermostatDatabase,
+          $ThermostatStateEntriesTable,
+          ThermostatStateEntry,
+          $$ThermostatStateEntriesTableFilterComposer,
+          $$ThermostatStateEntriesTableOrderingComposer,
+          $$ThermostatStateEntriesTableAnnotationComposer,
+          $$ThermostatStateEntriesTableCreateCompanionBuilder,
+          $$ThermostatStateEntriesTableUpdateCompanionBuilder,
+          (
+            ThermostatStateEntry,
+            BaseReferences<
+              _$ThermostatDatabase,
+              $ThermostatStateEntriesTable,
+              ThermostatStateEntry
+            >,
+          ),
+          ThermostatStateEntry,
+          PrefetchHooks Function()
+        > {
+  $$ThermostatStateEntriesTableTableManager(
+    _$ThermostatDatabase db,
+    $ThermostatStateEntriesTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$ThermostatStateEntriesTableFilterComposer(
+                $db: db,
+                $table: table,
+              ),
+          createOrderingComposer: () =>
+              $$ThermostatStateEntriesTableOrderingComposer(
+                $db: db,
+                $table: table,
+              ),
+          createComputedFieldComposer: () =>
+              $$ThermostatStateEntriesTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<String> thermostatId = const Value.absent(),
+                Value<double?> lastValueC = const Value.absent(),
+                Value<String?> lastStatus = const Value.absent(),
+                Value<DateTime?> lastFetchedAt = const Value.absent(),
+                Value<String?> etag = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime> updatedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => ThermostatStateEntriesCompanion(
+                thermostatId: thermostatId,
+                lastValueC: lastValueC,
+                lastStatus: lastStatus,
+                lastFetchedAt: lastFetchedAt,
+                etag: etag,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String thermostatId,
+                Value<double?> lastValueC = const Value.absent(),
+                Value<String?> lastStatus = const Value.absent(),
+                Value<DateTime?> lastFetchedAt = const Value.absent(),
+                Value<String?> etag = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime> updatedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => ThermostatStateEntriesCompanion.insert(
+                thermostatId: thermostatId,
+                lastValueC: lastValueC,
+                lastStatus: lastStatus,
+                lastFetchedAt: lastFetchedAt,
+                etag: etag,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$ThermostatStateEntriesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$ThermostatDatabase,
+      $ThermostatStateEntriesTable,
+      ThermostatStateEntry,
+      $$ThermostatStateEntriesTableFilterComposer,
+      $$ThermostatStateEntriesTableOrderingComposer,
+      $$ThermostatStateEntriesTableAnnotationComposer,
+      $$ThermostatStateEntriesTableCreateCompanionBuilder,
+      $$ThermostatStateEntriesTableUpdateCompanionBuilder,
+      (
+        ThermostatStateEntry,
+        BaseReferences<
+          _$ThermostatDatabase,
+          $ThermostatStateEntriesTable,
+          ThermostatStateEntry
+        >,
+      ),
+      ThermostatStateEntry,
+      PrefetchHooks Function()
+    >;
 
 class $ThermostatDatabaseManager {
   final _$ThermostatDatabase _db;
@@ -1620,4 +2375,9 @@ class $ThermostatDatabaseManager {
       $$ThermostatEntriesTableTableManager(_db, _db.thermostatEntries);
   $$AlertConfigEntriesTableTableManager get alertConfigEntries =>
       $$AlertConfigEntriesTableTableManager(_db, _db.alertConfigEntries);
+  $$ThermostatStateEntriesTableTableManager get thermostatStateEntries =>
+      $$ThermostatStateEntriesTableTableManager(
+        _db,
+        _db.thermostatStateEntries,
+      );
 }

--- a/app/lib/features/thermostats/data/thermostat_repository.dart
+++ b/app/lib/features/thermostats/data/thermostat_repository.dart
@@ -2,6 +2,7 @@ import 'package:drift/drift.dart' as drift;
 import 'package:uuid/uuid.dart';
 
 import '../models/thermostat.dart';
+import '../models/thermostat_state.dart';
 import 'thermostat_database.dart';
 
 final _uuid = const Uuid();
@@ -11,15 +12,33 @@ class ThermostatRepository {
 
   final ThermostatDatabase _database;
 
-  Stream<List<Thermostat>> watchThermostats() {
-    return _database.watchThermostats().map(
-      (rows) => rows.map(Thermostat.fromEntry).toList(),
+  Stream<List<ThermostatSummary>> watchThermostats() {
+    return _database.watchThermostatsWithState().map(
+      (rows) => rows
+          .map(
+            (row) => ThermostatSummary(
+              thermostat: Thermostat.fromEntry(row.thermostat),
+              state: row.state != null
+                  ? ThermostatState.fromEntry(row.state!)
+                  : null,
+            ),
+          )
+          .toList(),
     );
   }
 
-  Future<List<Thermostat>> fetchThermostats() async {
-    final rows = await _database.listThermostats();
-    return rows.map(Thermostat.fromEntry).toList();
+  Future<List<ThermostatSummary>> fetchThermostats() async {
+    final rows = await _database.listThermostatsWithState();
+    return rows
+        .map(
+          (row) => ThermostatSummary(
+            thermostat: Thermostat.fromEntry(row.thermostat),
+            state: row.state != null
+                ? ThermostatState.fromEntry(row.state!)
+                : null,
+          ),
+        )
+        .toList();
   }
 
   Future<Thermostat> create(ThermostatDraft draft) async {
@@ -77,5 +96,39 @@ class ThermostatRepository {
 
   Future<void> delete(String id) async {
     await _database.deleteThermostatById(id);
+    await _database.deleteThermostatStateById(id);
+  }
+
+  Future<ThermostatState?> loadState(String id) async {
+    final entry = await _database.getThermostatState(id);
+    if (entry == null) {
+      return null;
+    }
+    return ThermostatState.fromEntry(entry);
+  }
+
+  Future<void> saveState({
+    required String thermostatId,
+    required ThermostatReadingStatus status,
+    double? valueC,
+    DateTime? fetchedAt,
+    String? etag,
+  }) async {
+    final now = DateTime.now().toUtc();
+    await _database.upsertThermostatState(
+      ThermostatStateEntriesCompanion(
+        thermostatId: drift.Value(thermostatId),
+        lastStatus: drift.Value(status.name),
+        lastValueC: valueC != null
+            ? drift.Value(valueC)
+            : const drift.Value.absent(),
+        lastFetchedAt: fetchedAt != null
+            ? drift.Value(fetchedAt)
+            : const drift.Value.absent(),
+        etag: etag != null ? drift.Value(etag) : const drift.Value.absent(),
+        createdAt: const drift.Value.absent(),
+        updatedAt: drift.Value(now),
+      ),
+    );
   }
 }

--- a/app/lib/features/thermostats/data/thermostat_service.dart
+++ b/app/lib/features/thermostats/data/thermostat_service.dart
@@ -1,0 +1,54 @@
+import '../models/thermostat.dart';
+import '../models/thermostat_state.dart';
+import 'thermostat_client.dart';
+import 'thermostat_repository.dart';
+
+class ThermostatService {
+  ThermostatService({
+    required ThermostatRepository repository,
+    required ThermostatNetworkDataSource network,
+  }) : _repository = repository,
+       _network = network;
+
+  final ThermostatRepository _repository;
+  final ThermostatNetworkDataSource _network;
+
+  Future<Thermostat> createAndTest(ThermostatDraft draft) async {
+    final validation = ThermostatValidator.validate(draft);
+    if (!validation.isValid) {
+      throw ThermostatValidationException(validation);
+    }
+
+    final result = await _network.fetchCurrent(draft.rawUrl.trim());
+    final saved = await _repository.create(draft);
+    await _repository.saveState(
+      thermostatId: saved.id,
+      status: ThermostatReadingStatus.ok,
+      valueC: result.valueC,
+      fetchedAt: result.fetchedAt,
+      etag: result.etag,
+    );
+    return saved;
+  }
+
+  Future<Thermostat> updateAndTest(
+    Thermostat existing,
+    ThermostatDraft draft,
+  ) async {
+    final validation = ThermostatValidator.validate(draft);
+    if (!validation.isValid) {
+      throw ThermostatValidationException(validation);
+    }
+
+    final result = await _network.fetchCurrent(draft.rawUrl.trim());
+    final updated = await _repository.update(existing, draft);
+    await _repository.saveState(
+      thermostatId: updated.id,
+      status: ThermostatReadingStatus.ok,
+      valueC: result.valueC,
+      fetchedAt: result.fetchedAt,
+      etag: result.etag,
+    );
+    return updated;
+  }
+}

--- a/app/lib/features/thermostats/models/thermostat_state.dart
+++ b/app/lib/features/thermostats/models/thermostat_state.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/foundation.dart';
+
+import '../data/thermostat_database.dart';
+import 'thermostat.dart';
+
+@immutable
+class ThermostatState {
+  const ThermostatState({
+    required this.thermostatId,
+    required this.status,
+    this.lastValueC,
+    this.lastFetchedAt,
+    this.etag,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final String thermostatId;
+  final ThermostatReadingStatus status;
+  final double? lastValueC;
+  final DateTime? lastFetchedAt;
+  final String? etag;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  factory ThermostatState.fromEntry(ThermostatStateEntry entry) {
+    return ThermostatState(
+      thermostatId: entry.thermostatId,
+      status: ThermostatReadingStatusX.fromName(entry.lastStatus),
+      lastValueC: entry.lastValueC,
+      lastFetchedAt: entry.lastFetchedAt,
+      etag: entry.etag,
+      createdAt: entry.createdAt,
+      updatedAt: entry.updatedAt,
+    );
+  }
+
+  ThermostatState copyWith({
+    ThermostatReadingStatus? status,
+    double? lastValueC,
+    DateTime? lastFetchedAt,
+    String? etag,
+    DateTime? updatedAt,
+  }) {
+    return ThermostatState(
+      thermostatId: thermostatId,
+      status: status ?? this.status,
+      lastValueC: lastValueC ?? this.lastValueC,
+      lastFetchedAt: lastFetchedAt ?? this.lastFetchedAt,
+      etag: etag ?? this.etag,
+      createdAt: createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+}
+
+@immutable
+class ThermostatSummary {
+  const ThermostatSummary({required this.thermostat, this.state});
+
+  final Thermostat thermostat;
+  final ThermostatState? state;
+}
+
+enum ThermostatReadingStatus {
+  ok,
+  networkError,
+  httpError,
+  parseError,
+  unknown,
+}
+
+extension ThermostatReadingStatusX on ThermostatReadingStatus {
+  static ThermostatReadingStatus fromName(String? value) {
+    if (value == null || value.isEmpty) {
+      return ThermostatReadingStatus.unknown;
+    }
+    return ThermostatReadingStatus.values.firstWhere(
+      (status) => status.name == value,
+      orElse: () => ThermostatReadingStatus.unknown,
+    );
+  }
+}

--- a/app/lib/features/thermostats/providers/thermostat_providers.dart
+++ b/app/lib/features/thermostats/providers/thermostat_providers.dart
@@ -1,8 +1,10 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../data/thermostat_client.dart';
 import '../data/thermostat_database.dart';
 import '../data/thermostat_repository.dart';
-import '../models/thermostat.dart';
+import '../data/thermostat_service.dart';
+import '../models/thermostat_state.dart';
 
 final thermostatDatabaseProvider = Provider<ThermostatDatabase>((ref) {
   final database = ThermostatDatabase();
@@ -15,7 +17,17 @@ final thermostatRepositoryProvider = Provider<ThermostatRepository>((ref) {
   return ThermostatRepository(database);
 });
 
-final thermostatsProvider = StreamProvider<List<Thermostat>>((ref) {
+final thermostatNetworkProvider = Provider<ThermostatNetworkDataSource>((ref) {
+  return ThermostatHttpClient();
+});
+
+final thermostatServiceProvider = Provider<ThermostatService>((ref) {
+  final repository = ref.watch(thermostatRepositoryProvider);
+  final network = ref.watch(thermostatNetworkProvider);
+  return ThermostatService(repository: repository, network: network);
+});
+
+final thermostatsProvider = StreamProvider<List<ThermostatSummary>>((ref) {
   final repository = ref.watch(thermostatRepositoryProvider);
   return repository.watchThermostats();
 });

--- a/app/lib/features/thermostats/view/thermostats_page.dart
+++ b/app/lib/features/thermostats/view/thermostats_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/thermostat.dart';
+import '../models/thermostat_state.dart';
 import '../providers/thermostat_providers.dart';
 import '../widgets/thermostat_card.dart';
 import '../widgets/thermostat_form_dialog.dart';
@@ -10,96 +11,57 @@ class ThermostatsPage extends ConsumerWidget {
   const ThermostatsPage({super.key});
 
   Future<void> _createThermostat(BuildContext context, WidgetRef ref) async {
-    final draft = await showDialog<ThermostatDraft>(
+    final saved = await showDialog<Thermostat>(
       context: context,
-      builder: (context) => const ThermostatFormDialog(),
+      builder: (context) => ThermostatFormDialog(
+        onSubmit: (draft) {
+          final service = ref.read(thermostatServiceProvider);
+          return service.createAndTest(draft);
+        },
+      ),
     );
 
-    if (!context.mounted) {
+    if (!context.mounted || saved == null) {
       return;
     }
 
-    if (draft == null) {
-      return;
-    }
-
-    final repository = ref.read(thermostatRepositoryProvider);
-    try {
-      await repository.create(draft);
-      if (!context.mounted) {
-        return;
-      }
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('Thermostat added.')));
-    } on ThermostatValidationException catch (error) {
-      final first = error.result.errors.first;
-      if (!context.mounted) {
-        return;
-      }
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(first.message)));
-    } catch (error) {
-      if (!context.mounted) {
-        return;
-      }
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to save thermostat: $error')),
-      );
-    }
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('Thermostat added.')));
   }
 
   Future<void> _editThermostat(
     BuildContext context,
     WidgetRef ref,
-    Thermostat thermostat,
+    ThermostatSummary summary,
   ) async {
-    final draft = await showDialog<ThermostatDraft>(
+    final thermostat = summary.thermostat;
+    final updated = await showDialog<Thermostat>(
       context: context,
-      builder: (context) => ThermostatFormDialog(initial: thermostat),
+      builder: (context) => ThermostatFormDialog(
+        initial: thermostat,
+        onSubmit: (draft) {
+          final service = ref.read(thermostatServiceProvider);
+          return service.updateAndTest(thermostat, draft);
+        },
+      ),
     );
 
-    if (!context.mounted) {
+    if (!context.mounted || updated == null) {
       return;
     }
 
-    if (draft == null) {
-      return;
-    }
-
-    final repository = ref.read(thermostatRepositoryProvider);
-    try {
-      await repository.update(thermostat, draft);
-      if (!context.mounted) {
-        return;
-      }
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('Thermostat updated.')));
-    } on ThermostatValidationException catch (error) {
-      final first = error.result.errors.first;
-      if (!context.mounted) {
-        return;
-      }
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(first.message)));
-    } catch (error) {
-      if (!context.mounted) {
-        return;
-      }
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to update thermostat: $error')),
-      );
-    }
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('Thermostat updated.')));
   }
 
   Future<void> _deleteThermostat(
     BuildContext context,
     WidgetRef ref,
-    Thermostat thermostat,
+    ThermostatSummary summary,
   ) async {
+    final thermostat = summary.thermostat;
     final confirm = await showDialog<bool>(
       context: context,
       builder: (context) {
@@ -162,11 +124,11 @@ class ThermostatsPage extends ConsumerWidget {
           return ListView.separated(
             padding: const EdgeInsets.all(16),
             itemBuilder: (context, index) {
-              final thermostat = thermostats[index];
+              final summary = thermostats[index];
               return ThermostatCard(
-                thermostat: thermostat,
-                onEdit: () => _editThermostat(context, ref, thermostat),
-                onDelete: () => _deleteThermostat(context, ref, thermostat),
+                summary: summary,
+                onEdit: () => _editThermostat(context, ref, summary),
+                onDelete: () => _deleteThermostat(context, ref, summary),
               );
             },
             separatorBuilder: (context, index) => const SizedBox(height: 12),

--- a/app/lib/features/thermostats/widgets/thermostat_card.dart
+++ b/app/lib/features/thermostats/widgets/thermostat_card.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 
-import '../models/thermostat.dart';
 import '../models/thermostat_state.dart';
 
 class ThermostatCard extends StatelessWidget {

--- a/app/lib/features/thermostats/widgets/thermostat_card.dart
+++ b/app/lib/features/thermostats/widgets/thermostat_card.dart
@@ -1,16 +1,17 @@
 import 'package:flutter/material.dart';
 
 import '../models/thermostat.dart';
+import '../models/thermostat_state.dart';
 
 class ThermostatCard extends StatelessWidget {
   const ThermostatCard({
-    required this.thermostat,
+    required this.summary,
     this.onEdit,
     this.onDelete,
     super.key,
   });
 
-  final Thermostat thermostat;
+  final ThermostatSummary summary;
   final VoidCallback? onEdit;
   final VoidCallback? onDelete;
 
@@ -19,6 +20,8 @@ class ThermostatCard extends StatelessWidget {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final textTheme = theme.textTheme;
+    final thermostat = summary.thermostat;
+    final state = summary.state;
 
     return Card(
       clipBehavior: Clip.antiAlias,
@@ -83,6 +86,8 @@ class ThermostatCard extends StatelessWidget {
                 ),
               ],
             ),
+            const SizedBox(height: 12),
+            _LastSeenStatus(state: state),
           ],
         ),
       ),
@@ -91,3 +96,75 @@ class ThermostatCard extends StatelessWidget {
 }
 
 enum _ThermostatMenuAction { edit, delete }
+
+class _LastSeenStatus extends StatelessWidget {
+  const _LastSeenStatus({this.state});
+
+  final ThermostatState? state;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    if (state == null || state!.lastFetchedAt == null) {
+      return Text(
+        'No successful readings yet.',
+        style: textTheme.bodyMedium?.copyWith(
+          color: colorScheme.onSurfaceVariant,
+        ),
+      );
+    }
+
+    final fetchedAt = state!.lastFetchedAt!;
+    final value = state!.lastValueC;
+    final status = state!.status;
+    final now = DateTime.now().toUtc();
+    final difference = now.difference(fetchedAt);
+    final relative = _formatRelativeDuration(difference);
+
+    final statusText = switch (status) {
+      ThermostatReadingStatus.ok =>
+        value != null
+            ? '${value.toStringAsFixed(1)}°C • Updated $relative'
+            : 'Updated $relative',
+      ThermostatReadingStatus.networkError =>
+        'Last attempt failed: network error',
+      ThermostatReadingStatus.httpError => 'Last attempt failed: server error',
+      ThermostatReadingStatus.parseError =>
+        'Last attempt failed: invalid payload',
+      ThermostatReadingStatus.unknown => 'Last seen $relative',
+    };
+
+    final isError = status != ThermostatReadingStatus.ok;
+
+    return Text(
+      statusText,
+      style: textTheme.bodyMedium?.copyWith(
+        color: isError ? colorScheme.error : colorScheme.onSurfaceVariant,
+      ),
+    );
+  }
+
+  String _formatRelativeDuration(Duration difference) {
+    final seconds = difference.inSeconds.abs();
+    if (seconds < 60) {
+      return 'just now';
+    }
+    final minutes = difference.inMinutes;
+    if (minutes.abs() < 60) {
+      final value = minutes.abs();
+      final unit = value == 1 ? 'min' : 'mins';
+      return '$value $unit ago';
+    }
+    final hours = difference.inHours;
+    if (hours.abs() < 24) {
+      final value = hours.abs();
+      final unit = value == 1 ? 'hour' : 'hours';
+      return '$value $unit ago';
+    }
+    final days = difference.inDays;
+    final unit = days.abs() == 1 ? 'day' : 'days';
+    return '${days.abs()} $unit ago';
+  }
+}

--- a/app/lib/features/thermostats/widgets/thermostat_form_dialog.dart
+++ b/app/lib/features/thermostats/widgets/thermostat_form_dialog.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 
+import '../data/thermostat_client.dart';
 import '../models/thermostat.dart';
 
 class ThermostatFormDialog extends StatefulWidget {
-  const ThermostatFormDialog({super.key, this.initial});
+  const ThermostatFormDialog({required this.onSubmit, this.initial, super.key});
 
+  final Future<Thermostat> Function(ThermostatDraft draft) onSubmit;
   final Thermostat? initial;
 
   @override
@@ -19,6 +21,8 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
   late final TextEditingController _maxController;
   String? _rangeError;
   Map<ThermostatValidationField, String> _fieldErrors = {};
+  String? _submitError;
+  bool _isSubmitting = false;
 
   @override
   void initState() {
@@ -43,11 +47,12 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
     super.dispose();
   }
 
-  void _submit() {
+  Future<void> _submit() async {
     FocusScope.of(context).unfocus();
     setState(() {
       _fieldErrors = {};
       _rangeError = null;
+      _submitError = null;
     });
 
     if (!_formKey.currentState!.validate()) {
@@ -76,8 +81,8 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
     }
 
     final draft = ThermostatDraft(
-      name: _nameController.text,
-      rawUrl: _urlController.text,
+      name: _nameController.text.trim(),
+      rawUrl: _urlController.text.trim(),
       minC: minValue,
       maxC: maxValue,
     );
@@ -97,7 +102,50 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
       return;
     }
 
-    Navigator.of(context).pop(draft);
+    setState(() {
+      _isSubmitting = true;
+    });
+
+    try {
+      final saved = await widget.onSubmit(draft);
+      if (!mounted) {
+        return;
+      }
+      Navigator.of(context).pop(saved);
+    } on ThermostatValidationException catch (error) {
+      final map = <ThermostatValidationField, String>{};
+      String? rangeError;
+      for (final item in error.result.errors) {
+        map[item.field] = item.message;
+        if (item.field == ThermostatValidationField.range) {
+          rangeError = item.message;
+        }
+      }
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _fieldErrors = map;
+        _rangeError = rangeError;
+        _isSubmitting = false;
+      });
+    } on ThermostatFetchException catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _submitError = error.message;
+        _isSubmitting = false;
+      });
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _submitError = 'Failed to save thermostat: $error';
+        _isSubmitting = false;
+      });
+    }
   }
 
   @override
@@ -119,6 +167,7 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
                 ),
                 textCapitalization: TextCapitalization.words,
                 autofocus: true,
+                enabled: !_isSubmitting,
                 validator: (value) {
                   if (value == null || value.trim().isEmpty) {
                     return 'Enter a name.';
@@ -135,6 +184,7 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
                   errorText: _fieldErrors[ThermostatValidationField.rawUrl],
                 ),
                 keyboardType: TextInputType.url,
+                enabled: !_isSubmitting,
                 validator: (value) {
                   if (value == null || value.trim().isEmpty) {
                     return 'Enter a raw URL.';
@@ -156,6 +206,7 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
                         signed: true,
                         decimal: true,
                       ),
+                      enabled: !_isSubmitting,
                     ),
                   ),
                   const SizedBox(width: 16),
@@ -170,6 +221,7 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
                         signed: true,
                         decimal: true,
                       ),
+                      enabled: !_isSubmitting,
                     ),
                   ),
                 ],
@@ -186,18 +238,36 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
                   ),
                 ),
               ],
+              if (_submitError != null) ...[
+                const SizedBox(height: 12),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    _submitError!,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+                  ),
+                ),
+              ],
             ],
           ),
         ),
       ),
       actions: [
         TextButton(
-          onPressed: () => Navigator.of(context).pop(),
+          onPressed: _isSubmitting ? null : () => Navigator.of(context).pop(),
           child: const Text('Cancel'),
         ),
         FilledButton(
-          onPressed: _submit,
-          child: Text(isEditing ? 'Save' : 'Add'),
+          onPressed: _isSubmitting ? null : _submit,
+          child: _isSubmitting
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('Test & Save'),
         ),
       ],
     );

--- a/app/test/unit/thermostat_client_test.dart
+++ b/app/test/unit/thermostat_client_test.dart
@@ -1,0 +1,107 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:farmctl/features/thermostats/data/thermostat_client.dart';
+import 'package:farmctl/features/thermostats/models/thermostat_state.dart';
+
+class _FakeAdapter implements HttpClientAdapter {
+  _FakeAdapter(this._handler);
+
+  final Future<ResponseBody> Function(RequestOptions options) _handler;
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) {
+    return _handler(options);
+  }
+}
+
+void main() {
+  test('fetchCurrent returns parsed temperature', () async {
+    final dio = Dio()
+      ..httpClientAdapter = _FakeAdapter((options) async {
+        expect(options.headers[HttpHeaders.acceptHeader], 'text/plain');
+        return ResponseBody.fromString('Temperature: 12.5 C', 200);
+      });
+
+    final client = ThermostatHttpClient(dio: dio);
+
+    final result = await client.fetchCurrent('https://example.com/raw');
+
+    expect(result.valueC, closeTo(12.5, 0.0001));
+    expect(result.etag, isNull);
+    expect(
+      DateTime.now().difference(result.fetchedAt).inSeconds.abs(),
+      lessThan(5),
+    );
+  });
+
+  test('fetchCurrent throws on parse error', () async {
+    final dio = Dio()
+      ..httpClientAdapter = _FakeAdapter(
+        (options) async => ResponseBody.fromString('invalid payload', 200),
+      );
+    final client = ThermostatHttpClient(dio: dio);
+
+    expect(
+      () => client.fetchCurrent('https://example.com/raw'),
+      throwsA(
+        isA<ThermostatFetchException>().having(
+          (error) => error.status,
+          'status',
+          ThermostatReadingStatus.parseError,
+        ),
+      ),
+    );
+  });
+
+  test('fetchCurrent throws on http error', () async {
+    final dio = Dio()
+      ..httpClientAdapter = _FakeAdapter(
+        (options) async => ResponseBody.fromString('not found', 404),
+      );
+    final client = ThermostatHttpClient(dio: dio);
+
+    expect(
+      () => client.fetchCurrent('https://example.com/raw'),
+      throwsA(
+        isA<ThermostatFetchException>().having(
+          (error) => error.status,
+          'status',
+          ThermostatReadingStatus.httpError,
+        ),
+      ),
+    );
+  });
+
+  test('fetchCurrent throws on network error', () async {
+    final dio = Dio()
+      ..httpClientAdapter = _FakeAdapter((options) async {
+        throw DioException(
+          requestOptions: options,
+          type: DioExceptionType.connectionError,
+          error: const SocketException('Failed host lookup'),
+        );
+      });
+    final client = ThermostatHttpClient(dio: dio);
+
+    expect(
+      () => client.fetchCurrent('https://example.com/raw'),
+      throwsA(
+        isA<ThermostatFetchException>().having(
+          (error) => error.status,
+          'status',
+          ThermostatReadingStatus.networkError,
+        ),
+      ),
+    );
+  });
+}

--- a/app/test/unit/thermostat_repository_test.dart
+++ b/app/test/unit/thermostat_repository_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:farmctl/features/thermostats/data/thermostat_database.dart';
 import 'package:farmctl/features/thermostats/data/thermostat_repository.dart';
 import 'package:farmctl/features/thermostats/models/thermostat.dart';
+import 'package:farmctl/features/thermostats/models/thermostat_state.dart';
 
 void main() {
   late ThermostatDatabase database;
@@ -31,7 +32,7 @@ void main() {
 
     expect(created.name, draft.name);
     expect(stored, hasLength(1));
-    expect(stored.first.id, created.id);
+    expect(stored.first.thermostat.id, created.id);
   });
 
   test('update applies changes', () async {
@@ -70,10 +71,20 @@ void main() {
       ),
     );
 
+    await repository.saveState(
+      thermostatId: thermostat.id,
+      status: ThermostatReadingStatus.ok,
+      valueC: 12.3,
+      fetchedAt: DateTime.utc(2025, 1, 1, 12),
+      etag: 'etag',
+    );
+
     await repository.delete(thermostat.id);
     final stored = await repository.fetchThermostats();
 
     expect(stored, isEmpty);
+    final state = await repository.loadState(thermostat.id);
+    expect(state, isNull);
   });
 
   test('create throws on invalid data', () async {
@@ -88,5 +99,42 @@ void main() {
       () => repository.create(draft),
       throwsA(isA<ThermostatValidationException>()),
     );
+  });
+
+  test('saveState upserts thermostat state', () async {
+    final thermostat = await repository.create(
+      ThermostatDraft(
+        name: 'Nursery',
+        rawUrl: 'https://example.com/nursery',
+        minC: 5,
+        maxC: 18,
+      ),
+    );
+
+    await repository.saveState(
+      thermostatId: thermostat.id,
+      status: ThermostatReadingStatus.ok,
+      valueC: 9.5,
+      fetchedAt: DateTime.utc(2025, 1, 2, 8),
+      etag: 'tag',
+    );
+
+    var state = await repository.loadState(thermostat.id);
+    expect(state, isNotNull);
+    expect(state!.status, ThermostatReadingStatus.ok);
+    expect(state.lastValueC, 9.5);
+
+    await repository.saveState(
+      thermostatId: thermostat.id,
+      status: ThermostatReadingStatus.httpError,
+      valueC: null,
+      fetchedAt: DateTime.utc(2025, 1, 2, 9),
+      etag: null,
+    );
+
+    state = await repository.loadState(thermostat.id);
+    expect(state, isNotNull);
+    expect(state!.status, ThermostatReadingStatus.httpError);
+    expect(state.lastValueC, 9.5);
   });
 }

--- a/app/test/unit/thermostat_service_test.dart
+++ b/app/test/unit/thermostat_service_test.dart
@@ -1,0 +1,125 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:farmctl/features/thermostats/data/thermostat_client.dart';
+import 'package:farmctl/features/thermostats/data/thermostat_database.dart';
+import 'package:farmctl/features/thermostats/data/thermostat_repository.dart';
+import 'package:farmctl/features/thermostats/data/thermostat_service.dart';
+import 'package:farmctl/features/thermostats/models/thermostat.dart';
+import 'package:farmctl/features/thermostats/models/thermostat_state.dart';
+
+class _FakeNetworkDataSource implements ThermostatNetworkDataSource {
+  _FakeNetworkDataSource(this._result);
+
+  ThermostatFetchSuccess? _result;
+  ThermostatFetchException? _exception;
+
+  @override
+  Future<ThermostatFetchSuccess> fetchCurrent(String url) async {
+    if (_exception != null) {
+      throw _exception!;
+    }
+    final result = _result;
+    if (result == null) {
+      throw StateError('No result configured');
+    }
+    return result;
+  }
+}
+
+void main() {
+  late ThermostatDatabase database;
+  late ThermostatRepository repository;
+  late _FakeNetworkDataSource network;
+  late ThermostatService service;
+
+  setUp(() {
+    database = ThermostatDatabase.forTesting(NativeDatabase.memory());
+    repository = ThermostatRepository(database);
+    network = _FakeNetworkDataSource(
+      ThermostatFetchSuccess(
+        valueC: 14.2,
+        fetchedAt: DateTime.utc(2025, 1, 1, 12),
+        etag: 'etag',
+      ),
+    );
+    service = ThermostatService(repository: repository, network: network);
+  });
+
+  tearDown(() async {
+    await database.close();
+  });
+
+  test('createAndTest saves thermostat and state', () async {
+    final created = await service.createAndTest(
+      ThermostatDraft(
+        name: 'Barn',
+        rawUrl: 'https://example.com/barn',
+        minC: 0,
+        maxC: 20,
+      ),
+    );
+
+    final summaries = await repository.fetchThermostats();
+    expect(summaries, hasLength(1));
+    expect(summaries.first.thermostat.id, created.id);
+    final state = summaries.first.state;
+    expect(state, isNotNull);
+    expect(state!.status, ThermostatReadingStatus.ok);
+    expect(state.lastValueC, 14.2);
+  });
+
+  test('updateAndTest updates thermostat and state', () async {
+    final initial = await service.createAndTest(
+      ThermostatDraft(
+        name: 'Greenhouse',
+        rawUrl: 'https://example.com/greenhouse',
+        minC: 4,
+        maxC: 12,
+      ),
+    );
+
+    network._result = ThermostatFetchSuccess(
+      valueC: 9.0,
+      fetchedAt: DateTime.utc(2025, 1, 1, 13),
+      etag: 'next',
+    );
+
+    final updated = await service.updateAndTest(
+      initial,
+      ThermostatDraft(
+        name: 'Greenhouse West',
+        rawUrl: 'https://example.com/greenhouse-west',
+        minC: 3,
+        maxC: 11,
+      ),
+    );
+
+    expect(updated.name, 'Greenhouse West');
+    final state = await repository.loadState(updated.id);
+    expect(state, isNotNull);
+    expect(state!.lastValueC, 9.0);
+  });
+
+  test('createAndTest rethrows fetch errors', () async {
+    network._exception = const ThermostatFetchException(
+      status: ThermostatReadingStatus.networkError,
+      message: 'network error',
+    );
+
+    expect(
+      () => service.createAndTest(
+        ThermostatDraft(
+          name: 'Faulty',
+          rawUrl: 'https://example.com/faulty',
+          minC: 0,
+          maxC: 10,
+        ),
+      ),
+      throwsA(isA<ThermostatFetchException>()),
+    );
+
+    final summaries = await repository.fetchThermostats();
+    expect(summaries, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- add a Dio-based thermostat HTTP client with retries and parse validation
- extend the Drift database and repository to persist last readings and expose summaries
- wire a ThermostatService into the UI for Test & Save dialogs and last-seen status, with accompanying unit tests

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68ec264a6ba08325a770e314bc8de50e