### PR TITLE
Add background monitoring worker

### DIFF
--- a/.agent/ExecPlan.md
+++ b/.agent/ExecPlan.md
@@ -11,8 +11,8 @@ Deliver a production-ready Android app that monitors multiple thermostats via pu
 
 ## 🧱 Initial Requirements & Scope
 - In-scope (Android only):
-  - Thermostat CRUD with validation (HTTPS URL; tolerant parsing; °C only).
-  - Current reading via Gist raw URL; history via Gist revisions; local caching.
+  - Thermostat CRUD with validation (GitHub Gist ID; tolerant parsing; °C only).
+  - Current reading via GitHub Gist API (by Gist ID); history via Gist revisions; local caching.
   - Background watchdog with Foreground Service checks; out‑of‑range alarms with snooze/silence; optional exact alarms with permission.
   - Settings: poll interval, hysteresis toggle, global pause, sound picker with persisted URI permissions.
   - Accessibility and internationalization scaffolding; deterministic tests (unit, widget, integration), CI pipeline.
@@ -77,6 +77,8 @@ Use ☐/[-]/✅ with UTC timestamps to reflect real progress.
 - ✅ `[2025-10-13 14:00Z]` Implement Drift schema (thermostats, alert_config) and repositories; wire validation; CRUD UI integrated.
 - ✅ `[2025-10-13 20:00Z]` Implement background monitoring worker scaffold and unit tests; wire initial app entry.
 - ✅ `[2025-10-13 20:10Z]` Normalize thermostat state timestamps to UTC for consistency across layers.
+- ✅ `[2025-10-13 20:30Z]` Register plugins in WorkManager background isolate using DartPluginRegistrant; avoid native code.
+- ✅ `[2025-10-13 20:40Z]` Switch data source to GitHub Gist API with Gist ID only; update validation/UI/tests.
 - ☐ `[2025-10-14 16:00Z]` Implement HTTP client (timeouts/retries/headers) and Test & Save on add/edit.
 - ☐ `[2025-10-15 16:00Z]` Background periodic checks with Foreground execution; diagnostics log.
 - ☐ `[2025-10-16 16:00Z]` Range evaluation, alarm surface with snooze/silence; rate limiting.
@@ -91,6 +93,8 @@ Use ☐/[-]/✅ with UTC timestamps to reflect real progress.
 - Added Drift persistence for thermostats and alert config; integrated CRUD with validation and wired initial widget tests.
 - Added background monitoring scaffold using WorkManager with entrypoint wiring and initial tests.
 - Normalized thermostat timestamps to UTC to avoid device/timezone skew and simplify comparisons.
+- Registered plugins in the background isolate (no native code) to enable notifications and path provider.
+- Switched to GitHub Gist API with Gist ID–only configuration; simplified client and tests.
 
 ---
 
@@ -108,6 +112,8 @@ Use ☐/[-]/✅ with UTC timestamps to reflect real progress.
 - `[2025-10-13]` Persistence technology — Adopt Drift for typed schema and stream queries; impact: simpler migrations and reactive UI wiring.
 - `[2025-10-13]` IDs — Use UUIDs for thermostats; impact: future‑proofing for potential sync and uniqueness guarantees.
 - `[2025-10-13]` Time semantics — Normalize all stored/processed thermostat timestamps to UTC; impact: consistent comparisons, predictable testing, easier cross‑device behavior.
+- `[2025-10-13]` Background isolate plugins — Use DartPluginRegistrant.ensureInitialized() to register plugins in WorkManager isolate; impact: avoids MissingPluginException without native code.
+- `[2025-10-13]` Data source input — Prefer GitHub Gist ID only and fetch via Gist API, deprecating raw URL input; impact: simpler UX and more robust fetching.
 
 ---
 

--- a/.agent/ExecPlan.md
+++ b/.agent/ExecPlan.md
@@ -75,6 +75,8 @@ Use ☐/[-]/✅ with UTC timestamps to reflect real progress.
 - ✅ `[2025-10-12 18:10Z]` Set Android targets minSdk 26, targetSdk 34; enable core library desugaring.
 - ✅ `[2025-10-12 19:00Z]` Update documentation to reflect Flutter‑first approach and Gate A.
 - ✅ `[2025-10-13 14:00Z]` Implement Drift schema (thermostats, alert_config) and repositories; wire validation; CRUD UI integrated.
+- ✅ `[2025-10-13 20:00Z]` Implement background monitoring worker scaffold and unit tests; wire initial app entry.
+- ✅ `[2025-10-13 20:10Z]` Normalize thermostat state timestamps to UTC for consistency across layers.
 - ☐ `[2025-10-14 16:00Z]` Implement HTTP client (timeouts/retries/headers) and Test & Save on add/edit.
 - ☐ `[2025-10-15 16:00Z]` Background periodic checks with Foreground execution; diagnostics log.
 - ☐ `[2025-10-16 16:00Z]` Range evaluation, alarm surface with snooze/silence; rate limiting.
@@ -87,6 +89,8 @@ Use ☐/[-]/✅ with UTC timestamps to reflect real progress.
 - Adopted Flutter‑first plan with Milestone Gate A; delayed any native work until after reliability validation.
 - Standardized to Celsius; removed Fahrenheit references across parsing/tests/UI.
 - Added Drift persistence for thermostats and alert config; integrated CRUD with validation and wired initial widget tests.
+- Added background monitoring scaffold using WorkManager with entrypoint wiring and initial tests.
+- Normalized thermostat timestamps to UTC to avoid device/timezone skew and simplify comparisons.
 
 ---
 
@@ -103,6 +107,7 @@ Use ☐/[-]/✅ with UTC timestamps to reflect real progress.
 - `[2025-10-12]` Build toolchain — Enable core library desugaring to satisfy dependencies; impact: unblocked builds.
 - `[2025-10-13]` Persistence technology — Adopt Drift for typed schema and stream queries; impact: simpler migrations and reactive UI wiring.
 - `[2025-10-13]` IDs — Use UUIDs for thermostats; impact: future‑proofing for potential sync and uniqueness guarantees.
+- `[2025-10-13]` Time semantics — Normalize all stored/processed thermostat timestamps to UTC; impact: consistent comparisons, predictable testing, easier cross‑device behavior.
 
 ---
 

--- a/.agent/ExecPlan.md
+++ b/.agent/ExecPlan.md
@@ -5,7 +5,7 @@ This ExecPlan is a living document spanning design through implementation. It co
 ---
 
 ## 🎯 Purpose / Big Picture
-Deliver a production-ready Android app that monitors multiple thermostats via public GitHub Gist raw URLs, evaluates per‑thermostat operating ranges, and raises reliable audible alarms (Android alarm-like behavior) when out of range. Users can add/edit/remove thermostats, view current readings and historical graphs, configure watchdog cadence and alarm sound, and rely on background checks that continue across reboots. The milestone sequence validates a Flutter‑first approach with a decision gate (Gate A) to determine whether a minimal native shim is needed for reliability under Doze/lockscreen/OEM constraints.
+Deliver a production-ready Android app that monitors multiple thermostats via GitHub Gist API, evaluates per‑thermostat operating ranges, and raises reliable audible alarms (Android alarm-like behavior) when out of range. Users can add/edit/remove thermostats, view current readings and historical graphs, configure watchdog cadence and alarm sound, and rely on background checks that continue across reboots. The milestone sequence validates a Flutter‑first approach with a decision gate (Gate A) to determine whether a minimal native shim is needed for reliability under Doze/lockscreen/OEM constraints.
 
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .tooling/
 **/.dart_tool/
 **/build/
+**/generated_plugin_**

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .tooling/
 **/.dart_tool/
 **/build/
-**/generated_plugin_**
+generated_plugin_**

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .tooling/
 **/.dart_tool/
 **/build/
-generated_plugin_**
+**/generated_plugin_**

--- a/app/lib/core/background/thermostat_monitor.dart
+++ b/app/lib/core/background/thermostat_monitor.dart
@@ -1,3 +1,4 @@
+import 'dart:ui' as ui;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:workmanager/workmanager.dart';
@@ -47,6 +48,7 @@ Future<void> initializeBackgroundMonitoring({
 void thermostatMonitorCallbackDispatcher() {
   Workmanager().executeTask((taskName, inputData) async {
     WidgetsFlutterBinding.ensureInitialized();
+    ui.DartPluginRegistrant.ensureInitialized();
 
     final notifications = FlutterLocalNotificationsPlugin();
     await _initializeNotifications(notifications);

--- a/app/lib/core/background/thermostat_monitor.dart
+++ b/app/lib/core/background/thermostat_monitor.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:workmanager/workmanager.dart';
+
+import '../../features/thermostats/data/thermostat_client.dart';
+import '../../features/thermostats/data/thermostat_database.dart';
+import '../../features/thermostats/data/thermostat_repository.dart';
+import '../../features/thermostats/models/thermostat_state.dart';
+
+const String thermostatMonitorTask = 'thermostat_monitor_task';
+const String thermostatMonitorUniqueName = 'thermostat_monitor_periodic';
+
+const AndroidNotificationChannel _monitoringChannel = AndroidNotificationChannel(
+  'farmctl_monitoring',
+  'Thermostat monitoring',
+  description: 'Shows when FarmCtl is checking thermostats in the background.',
+  importance: Importance.low,
+);
+
+const int _monitoringNotificationId = 1001;
+const Duration _minimumFrequency = Duration(minutes: 15);
+
+Future<void> initializeBackgroundMonitoring({
+  Duration pollFrequency = const Duration(minutes: 5),
+}) async {
+  // Ensure notification channel exists even if the app has not shown one yet.
+  final notifications = FlutterLocalNotificationsPlugin();
+  await _initializeNotifications(notifications);
+
+  final effectiveFrequency = pollFrequency < _minimumFrequency
+      ? _minimumFrequency
+      : pollFrequency;
+
+  await Workmanager().initialize(thermostatMonitorCallbackDispatcher);
+  await Workmanager().registerPeriodicTask(
+    thermostatMonitorUniqueName,
+    thermostatMonitorTask,
+    frequency: effectiveFrequency,
+    existingWorkPolicy: ExistingPeriodicWorkPolicy.update,
+    constraints: const Constraints(networkType: NetworkType.connected),
+  );
+}
+
+@pragma('vm:entry-point')
+void thermostatMonitorCallbackDispatcher() {
+  Workmanager().executeTask((taskName, inputData) async {
+    WidgetsFlutterBinding.ensureInitialized();
+
+    final notifications = FlutterLocalNotificationsPlugin();
+    await _initializeNotifications(notifications);
+    await _showMonitoringNotification(notifications);
+
+    final database = ThermostatDatabase();
+    final repository = ThermostatRepository(database);
+    final network = ThermostatHttpClient();
+    final runner = ThermostatMonitorRunner(
+      repository: repository,
+      network: network,
+    );
+
+    try {
+      await runner.run();
+    } catch (error, stackTrace) {
+      debugPrint('Thermostat monitor failed: $error');
+      debugPrint('$stackTrace');
+    } finally {
+      await notifications.cancel(_monitoringNotificationId);
+      await database.close();
+    }
+
+    return true;
+  });
+}
+
+class ThermostatMonitorRunner {
+  ThermostatMonitorRunner({
+    required ThermostatRepository repository,
+    required ThermostatNetworkDataSource network,
+    DateTime Function()? clock,
+  })  : _repository = repository,
+        _network = network,
+        _clock = clock ?? () => DateTime.now().toUtc();
+
+  final ThermostatRepository _repository;
+  final ThermostatNetworkDataSource _network;
+  final DateTime Function() _clock;
+
+  Future<void> run() async {
+    final thermostats = await _repository.fetchThermostats();
+    for (final summary in thermostats) {
+      final thermostat = summary.thermostat;
+      if (!thermostat.monitoringEnabled) {
+        continue;
+      }
+
+      final previousState = summary.state;
+      try {
+        final result = await _network.fetchCurrent(thermostat.rawUrl);
+        await _repository.saveState(
+          thermostatId: thermostat.id,
+          status: ThermostatReadingStatus.ok,
+          valueC: result.valueC,
+          fetchedAt: result.fetchedAt,
+          etag: result.etag,
+          message: 'Fetched ${result.valueC.toStringAsFixed(1)}°C',
+        );
+      } on ThermostatFetchException catch (error) {
+        await _repository.saveState(
+          thermostatId: thermostat.id,
+          status: error.status,
+          valueC: previousState?.lastValueC,
+          fetchedAt: _clock(),
+          etag: previousState?.etag,
+          message: error.message,
+        );
+      } catch (error) {
+        await _repository.saveState(
+          thermostatId: thermostat.id,
+          status: ThermostatReadingStatus.unknown,
+          valueC: previousState?.lastValueC,
+          fetchedAt: _clock(),
+          etag: previousState?.etag,
+          message: 'Unexpected error: $error',
+        );
+      }
+    }
+  }
+}
+
+Future<void> _initializeNotifications(
+  FlutterLocalNotificationsPlugin plugin,
+) async {
+  const initializationSettings = InitializationSettings(
+    android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+  );
+  await plugin.initialize(initializationSettings);
+  final androidPlugin = plugin
+      .resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin>();
+  await androidPlugin?.createNotificationChannel(_monitoringChannel);
+}
+
+Future<void> _showMonitoringNotification(
+  FlutterLocalNotificationsPlugin plugin,
+) {
+  return plugin.show(
+    _monitoringNotificationId,
+    'FarmCtl monitoring',
+    'Checking thermostats…',
+    NotificationDetails(
+      android: AndroidNotificationDetails(
+        _monitoringChannel.id,
+        _monitoringChannel.name,
+        channelDescription: _monitoringChannel.description,
+        importance: Importance.low,
+        priority: Priority.low,
+        ongoing: true,
+        showWhen: false,
+        playSound: false,
+        enableVibration: false,
+      ),
+    ),
+  );
+}

--- a/app/lib/core/background/thermostat_monitor.dart
+++ b/app/lib/core/background/thermostat_monitor.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:workmanager/workmanager.dart';
@@ -11,12 +10,14 @@ import '../../features/thermostats/models/thermostat_state.dart';
 const String thermostatMonitorTask = 'thermostat_monitor_task';
 const String thermostatMonitorUniqueName = 'thermostat_monitor_periodic';
 
-const AndroidNotificationChannel _monitoringChannel = AndroidNotificationChannel(
-  'farmctl_monitoring',
-  'Thermostat monitoring',
-  description: 'Shows when FarmCtl is checking thermostats in the background.',
-  importance: Importance.low,
-);
+const AndroidNotificationChannel _monitoringChannel =
+    AndroidNotificationChannel(
+      'farmctl_monitoring',
+      'Thermostat monitoring',
+      description:
+          'Shows when FarmCtl is checking thermostats in the background.',
+      importance: Importance.low,
+    );
 
 const int _monitoringNotificationId = 1001;
 const Duration _minimumFrequency = Duration(minutes: 15);
@@ -38,7 +39,7 @@ Future<void> initializeBackgroundMonitoring({
     thermostatMonitorTask,
     frequency: effectiveFrequency,
     existingWorkPolicy: ExistingPeriodicWorkPolicy.update,
-    constraints: const Constraints(networkType: NetworkType.connected),
+    constraints: Constraints(networkType: NetworkType.connected),
   );
 }
 
@@ -78,13 +79,15 @@ class ThermostatMonitorRunner {
     required ThermostatRepository repository,
     required ThermostatNetworkDataSource network,
     DateTime Function()? clock,
-  })  : _repository = repository,
-        _network = network,
-        _clock = clock ?? () => DateTime.now().toUtc();
+  }) : _repository = repository,
+       _network = network,
+       _clock = clock ?? _defaultClock;
 
   final ThermostatRepository _repository;
   final ThermostatNetworkDataSource _network;
   final DateTime Function() _clock;
+
+  static DateTime _defaultClock() => DateTime.now().toUtc();
 
   Future<void> run() async {
     final thermostats = await _repository.fetchThermostats();
@@ -137,7 +140,8 @@ Future<void> _initializeNotifications(
   await plugin.initialize(initializationSettings);
   final androidPlugin = plugin
       .resolvePlatformSpecificImplementation<
-          AndroidFlutterLocalNotificationsPlugin>();
+        AndroidFlutterLocalNotificationsPlugin
+      >();
   await androidPlugin?.createNotificationChannel(_monitoringChannel);
 }
 

--- a/app/lib/features/thermostats/data/thermostat_client.dart
+++ b/app/lib/features/thermostats/data/thermostat_client.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:convert';
 
 import 'package:dio/dio.dart';
 import 'package:dio_smart_retry/dio_smart_retry.dart';
@@ -7,7 +8,7 @@ import 'package:farmctl_parsing/temperature_parser.dart';
 import '../models/thermostat_state.dart';
 
 abstract class ThermostatNetworkDataSource {
-  Future<ThermostatFetchSuccess> fetchCurrent(String url);
+  Future<ThermostatFetchSuccess> fetchCurrent(String gistId);
 }
 
 class ThermostatHttpClient implements ThermostatNetworkDataSource {
@@ -46,13 +47,49 @@ class ThermostatHttpClient implements ThermostatNetworkDataSource {
   }
 
   @override
-  Future<ThermostatFetchSuccess> fetchCurrent(String url) async {
+  Future<ThermostatFetchSuccess> fetchCurrent(String gistId) async {
+    try {
+      final input = gistId.trim();
+      if (!_looksLikeGistId(input)) {
+        throw ThermostatFetchException(
+          status: ThermostatReadingStatus.parseError,
+          message: 'Invalid Gist ID.',
+        );
+      }
+      return _fetchFromGistApi(input);
+    } on ThermostatFetchException {
+      rethrow;
+    } on DioException catch (error) {
+      throw ThermostatFetchException(
+        status: ThermostatReadingStatus.networkError,
+        message: 'Failed to reach GitHub Gist API.',
+        cause: error,
+      );
+    } catch (error) {
+      throw ThermostatFetchException(
+        status: ThermostatReadingStatus.networkError,
+        message: 'Failed to fetch from Gist API.',
+        cause: error,
+      );
+    }
+  }
+
+  bool _looksLikeGistId(String input) {
+    // Gist IDs are hex, typically 32 or 40 chars depending on legacy/full length.
+    final re = RegExp(r'^[0-9a-fA-F]{32,40}$');
+    return re.hasMatch(input);
+  }
+
+  Future<ThermostatFetchSuccess> _fetchFromGistApi(String gistId) async {
     try {
       final response = await _dio.get<String>(
-        url,
+        'https://api.github.com/gists/$gistId',
         options: Options(
           responseType: ResponseType.plain,
-          headers: const {HttpHeaders.acceptHeader: 'text/plain'},
+          headers: const {
+            HttpHeaders.acceptHeader: 'application/vnd.github+json',
+            HttpHeaders.userAgentHeader: 'farmctl/0.1',
+          },
         ),
       );
 
@@ -61,20 +98,69 @@ class ThermostatHttpClient implements ThermostatNetworkDataSource {
         throw ThermostatFetchException(
           status: ThermostatReadingStatus.httpError,
           statusCode: statusCode,
-          message: 'Request failed with status $statusCode.',
+          message: 'Gist API failed with status $statusCode.',
         );
       }
 
-      final body = response.data ?? '';
-      final value = parseCelsiusTemperature(body);
+      final raw = response.data ?? '';
+      final decoded = jsonDecode(raw) as Map<String, dynamic>;
+      final files = (decoded['files'] as Map<String, dynamic>?) ?? {};
+      if (files.isEmpty) {
+        throw ThermostatFetchException(
+          status: ThermostatReadingStatus.parseError,
+          message: 'Gist contains no files.',
+        );
+      }
+
+      // Choose a file: prefer names containing 'thermostat' or '.txt', else first.
+      MapEntry<String, dynamic> chosen = files.entries.first;
+      for (final entry in files.entries) {
+        final name = entry.key.toLowerCase();
+        if (name.contains('thermostat') || name.endsWith('.txt')) {
+          chosen = entry;
+          break;
+        }
+      }
+
+      final fileObj = chosen.value as Map<String, dynamic>;
+      final bool truncated = (fileObj['truncated'] as bool?) ?? false;
+      String? content = fileObj['content'] as String?;
+      if (content == null || truncated) {
+        final rawUrl = fileObj['raw_url'] as String?;
+        if (rawUrl == null || rawUrl.isEmpty) {
+          throw ThermostatFetchException(
+            status: ThermostatReadingStatus.parseError,
+            message: 'Gist file content unavailable.',
+          );
+        }
+        // Fallback: fetch the raw content.
+        final rawResp = await _dio.get<String>(
+          rawUrl,
+          options: Options(
+            responseType: ResponseType.plain,
+            headers: const {HttpHeaders.acceptHeader: 'text/plain'},
+          ),
+        );
+        if ((rawResp.statusCode ?? 0) != 200) {
+          throw ThermostatFetchException(
+            status: ThermostatReadingStatus.httpError,
+            statusCode: rawResp.statusCode ?? 0,
+            message: 'Raw fetch failed with status ${rawResp.statusCode}.',
+          );
+        }
+        content = rawResp.data ?? '';
+      }
+
+      final value = parseCelsiusTemperature(content);
       if (value == null) {
         throw ThermostatFetchException(
           status: ThermostatReadingStatus.parseError,
-          message: 'Response did not include a Celsius temperature.',
+          message: 'Gist content did not include a Celsius temperature.',
         );
       }
 
       final fetchedAt = DateTime.now().toUtc();
+      // ETag may be present on raw fetch; GitHub API ETag is not stable for parsing here.
       final etag = response.headers.value(HttpHeaders.etagHeader);
       return ThermostatFetchSuccess(
         valueC: value,
@@ -89,30 +175,26 @@ class ThermostatHttpClient implements ThermostatNetworkDataSource {
         throw ThermostatFetchException(
           status: ThermostatReadingStatus.httpError,
           statusCode: statusCode,
-          message: 'Request failed with status $statusCode.',
+          message: 'Gist API failed with status $statusCode.',
           cause: error,
         );
       }
-      final isTimeout =
-          error.type == DioExceptionType.connectionTimeout ||
-          error.type == DioExceptionType.sendTimeout ||
-          error.type == DioExceptionType.receiveTimeout;
       throw ThermostatFetchException(
         status: ThermostatReadingStatus.networkError,
-        message: isTimeout
-            ? 'Request timed out. Check the URL and try again.'
-            : 'Failed to reach the thermostat source.',
+        message: 'Failed to reach GitHub Gist API.',
         cause: error,
       );
     } catch (error) {
       throw ThermostatFetchException(
         status: ThermostatReadingStatus.networkError,
-        message: 'Failed to fetch thermostat data.',
+        message: 'Failed to fetch from Gist API.',
         cause: error,
       );
     }
   }
 }
+
+// Removed URL normalization: we accept only Gist IDs now.
 
 class ThermostatFetchSuccess {
   const ThermostatFetchSuccess({

--- a/app/lib/features/thermostats/data/thermostat_database.dart
+++ b/app/lib/features/thermostats/data/thermostat_database.dart
@@ -43,6 +43,8 @@ class ThermostatStateEntries extends Table {
 
   TextColumn get etag => text().nullable()();
 
+  TextColumn get statusMessage => text().nullable()();
+
   DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
 
   DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
@@ -90,7 +92,7 @@ class ThermostatDatabase extends _$ThermostatDatabase {
   ThermostatDatabase.forTesting(super.executor);
 
   @override
-  int get schemaVersion => 2;
+  int get schemaVersion => 3;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -100,6 +102,12 @@ class ThermostatDatabase extends _$ThermostatDatabase {
     onUpgrade: (Migrator m, int from, int to) async {
       if (from < 2) {
         await m.createTable(thermostatStateEntries);
+      }
+      if (from < 3) {
+        await m.addColumn(
+          thermostatStateEntries,
+          thermostatStateEntries.statusMessage,
+        );
       }
     },
   );

--- a/app/lib/features/thermostats/data/thermostat_database.g.dart
+++ b/app/lib/features/thermostats/data/thermostat_database.g.dart
@@ -1109,6 +1109,16 @@ class $ThermostatStateEntriesTable extends ThermostatStateEntries
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _statusMessageMeta =
+      const VerificationMeta('statusMessage');
+  @override
+  late final GeneratedColumn<String> statusMessage = GeneratedColumn<String>(
+    'status_message',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
   static const VerificationMeta _createdAtMeta = const VerificationMeta(
     'createdAt',
   );
@@ -1140,6 +1150,7 @@ class $ThermostatStateEntriesTable extends ThermostatStateEntries
     lastStatus,
     lastFetchedAt,
     etag,
+    statusMessage,
     createdAt,
     updatedAt,
   ];
@@ -1196,6 +1207,15 @@ class $ThermostatStateEntriesTable extends ThermostatStateEntries
         etag.isAcceptableOrUnknown(data['etag']!, _etagMeta),
       );
     }
+    if (data.containsKey('status_message')) {
+      context.handle(
+        _statusMessageMeta,
+        statusMessage.isAcceptableOrUnknown(
+          data['status_message']!,
+          _statusMessageMeta,
+        ),
+      );
+    }
     if (data.containsKey('created_at')) {
       context.handle(
         _createdAtMeta,
@@ -1237,6 +1257,10 @@ class $ThermostatStateEntriesTable extends ThermostatStateEntries
         DriftSqlType.string,
         data['${effectivePrefix}etag'],
       ),
+      statusMessage: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}status_message'],
+      ),
       createdAt: attachedDatabase.typeMapping.read(
         DriftSqlType.dateTime,
         data['${effectivePrefix}created_at'],
@@ -1261,6 +1285,7 @@ class ThermostatStateEntry extends DataClass
   final String? lastStatus;
   final DateTime? lastFetchedAt;
   final String? etag;
+  final String? statusMessage;
   final DateTime createdAt;
   final DateTime updatedAt;
   const ThermostatStateEntry({
@@ -1269,6 +1294,7 @@ class ThermostatStateEntry extends DataClass
     this.lastStatus,
     this.lastFetchedAt,
     this.etag,
+    this.statusMessage,
     required this.createdAt,
     required this.updatedAt,
   });
@@ -1288,6 +1314,9 @@ class ThermostatStateEntry extends DataClass
     if (!nullToAbsent || etag != null) {
       map['etag'] = Variable<String>(etag);
     }
+    if (!nullToAbsent || statusMessage != null) {
+      map['status_message'] = Variable<String>(statusMessage);
+    }
     map['created_at'] = Variable<DateTime>(createdAt);
     map['updated_at'] = Variable<DateTime>(updatedAt);
     return map;
@@ -1306,6 +1335,9 @@ class ThermostatStateEntry extends DataClass
           ? const Value.absent()
           : Value(lastFetchedAt),
       etag: etag == null && nullToAbsent ? const Value.absent() : Value(etag),
+      statusMessage: statusMessage == null && nullToAbsent
+          ? const Value.absent()
+          : Value(statusMessage),
       createdAt: Value(createdAt),
       updatedAt: Value(updatedAt),
     );
@@ -1322,6 +1354,7 @@ class ThermostatStateEntry extends DataClass
       lastStatus: serializer.fromJson<String?>(json['lastStatus']),
       lastFetchedAt: serializer.fromJson<DateTime?>(json['lastFetchedAt']),
       etag: serializer.fromJson<String?>(json['etag']),
+      statusMessage: serializer.fromJson<String?>(json['statusMessage']),
       createdAt: serializer.fromJson<DateTime>(json['createdAt']),
       updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
     );
@@ -1335,6 +1368,7 @@ class ThermostatStateEntry extends DataClass
       'lastStatus': serializer.toJson<String?>(lastStatus),
       'lastFetchedAt': serializer.toJson<DateTime?>(lastFetchedAt),
       'etag': serializer.toJson<String?>(etag),
+      'statusMessage': serializer.toJson<String?>(statusMessage),
       'createdAt': serializer.toJson<DateTime>(createdAt),
       'updatedAt': serializer.toJson<DateTime>(updatedAt),
     };
@@ -1346,6 +1380,7 @@ class ThermostatStateEntry extends DataClass
     Value<String?> lastStatus = const Value.absent(),
     Value<DateTime?> lastFetchedAt = const Value.absent(),
     Value<String?> etag = const Value.absent(),
+    Value<String?> statusMessage = const Value.absent(),
     DateTime? createdAt,
     DateTime? updatedAt,
   }) => ThermostatStateEntry(
@@ -1356,6 +1391,8 @@ class ThermostatStateEntry extends DataClass
         ? lastFetchedAt.value
         : this.lastFetchedAt,
     etag: etag.present ? etag.value : this.etag,
+    statusMessage:
+        statusMessage.present ? statusMessage.value : this.statusMessage,
     createdAt: createdAt ?? this.createdAt,
     updatedAt: updatedAt ?? this.updatedAt,
   );
@@ -1374,6 +1411,9 @@ class ThermostatStateEntry extends DataClass
           ? data.lastFetchedAt.value
           : this.lastFetchedAt,
       etag: data.etag.present ? data.etag.value : this.etag,
+      statusMessage: data.statusMessage.present
+          ? data.statusMessage.value
+          : this.statusMessage,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
     );
@@ -1387,6 +1427,7 @@ class ThermostatStateEntry extends DataClass
           ..write('lastStatus: $lastStatus, ')
           ..write('lastFetchedAt: $lastFetchedAt, ')
           ..write('etag: $etag, ')
+          ..write('statusMessage: $statusMessage, ')
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt')
           ..write(')'))
@@ -1400,6 +1441,7 @@ class ThermostatStateEntry extends DataClass
     lastStatus,
     lastFetchedAt,
     etag,
+    statusMessage,
     createdAt,
     updatedAt,
   );
@@ -1412,6 +1454,7 @@ class ThermostatStateEntry extends DataClass
           other.lastStatus == this.lastStatus &&
           other.lastFetchedAt == this.lastFetchedAt &&
           other.etag == this.etag &&
+          other.statusMessage == this.statusMessage &&
           other.createdAt == this.createdAt &&
           other.updatedAt == this.updatedAt);
 }
@@ -1423,6 +1466,7 @@ class ThermostatStateEntriesCompanion
   final Value<String?> lastStatus;
   final Value<DateTime?> lastFetchedAt;
   final Value<String?> etag;
+  final Value<String?> statusMessage;
   final Value<DateTime> createdAt;
   final Value<DateTime> updatedAt;
   final Value<int> rowid;
@@ -1432,6 +1476,7 @@ class ThermostatStateEntriesCompanion
     this.lastStatus = const Value.absent(),
     this.lastFetchedAt = const Value.absent(),
     this.etag = const Value.absent(),
+    this.statusMessage = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -1442,6 +1487,7 @@ class ThermostatStateEntriesCompanion
     this.lastStatus = const Value.absent(),
     this.lastFetchedAt = const Value.absent(),
     this.etag = const Value.absent(),
+    this.statusMessage = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -1452,6 +1498,7 @@ class ThermostatStateEntriesCompanion
     Expression<String>? lastStatus,
     Expression<DateTime>? lastFetchedAt,
     Expression<String>? etag,
+    Expression<String>? statusMessage,
     Expression<DateTime>? createdAt,
     Expression<DateTime>? updatedAt,
     Expression<int>? rowid,
@@ -1462,6 +1509,7 @@ class ThermostatStateEntriesCompanion
       if (lastStatus != null) 'last_status': lastStatus,
       if (lastFetchedAt != null) 'last_fetched_at': lastFetchedAt,
       if (etag != null) 'etag': etag,
+      if (statusMessage != null) 'status_message': statusMessage,
       if (createdAt != null) 'created_at': createdAt,
       if (updatedAt != null) 'updated_at': updatedAt,
       if (rowid != null) 'rowid': rowid,
@@ -1474,6 +1522,7 @@ class ThermostatStateEntriesCompanion
     Value<String?>? lastStatus,
     Value<DateTime?>? lastFetchedAt,
     Value<String?>? etag,
+    Value<String?>? statusMessage,
     Value<DateTime>? createdAt,
     Value<DateTime>? updatedAt,
     Value<int>? rowid,
@@ -1484,6 +1533,7 @@ class ThermostatStateEntriesCompanion
       lastStatus: lastStatus ?? this.lastStatus,
       lastFetchedAt: lastFetchedAt ?? this.lastFetchedAt,
       etag: etag ?? this.etag,
+      statusMessage: statusMessage ?? this.statusMessage,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
       rowid: rowid ?? this.rowid,
@@ -1508,6 +1558,9 @@ class ThermostatStateEntriesCompanion
     if (etag.present) {
       map['etag'] = Variable<String>(etag.value);
     }
+    if (statusMessage.present) {
+      map['status_message'] = Variable<String>(statusMessage.value);
+    }
     if (createdAt.present) {
       map['created_at'] = Variable<DateTime>(createdAt.value);
     }
@@ -1528,6 +1581,7 @@ class ThermostatStateEntriesCompanion
           ..write('lastStatus: $lastStatus, ')
           ..write('lastFetchedAt: $lastFetchedAt, ')
           ..write('etag: $etag, ')
+          ..write('statusMessage: $statusMessage, ')
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt, ')
           ..write('rowid: $rowid')

--- a/app/lib/features/thermostats/data/thermostat_database.g.dart
+++ b/app/lib/features/thermostats/data/thermostat_database.g.dart
@@ -1109,8 +1109,9 @@ class $ThermostatStateEntriesTable extends ThermostatStateEntries
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
-  static const VerificationMeta _statusMessageMeta =
-      const VerificationMeta('statusMessage');
+  static const VerificationMeta _statusMessageMeta = const VerificationMeta(
+    'statusMessage',
+  );
   @override
   late final GeneratedColumn<String> statusMessage = GeneratedColumn<String>(
     'status_message',
@@ -1391,8 +1392,9 @@ class ThermostatStateEntry extends DataClass
         ? lastFetchedAt.value
         : this.lastFetchedAt,
     etag: etag.present ? etag.value : this.etag,
-    statusMessage:
-        statusMessage.present ? statusMessage.value : this.statusMessage,
+    statusMessage: statusMessage.present
+        ? statusMessage.value
+        : this.statusMessage,
     createdAt: createdAt ?? this.createdAt,
     updatedAt: updatedAt ?? this.updatedAt,
   );

--- a/app/lib/features/thermostats/data/thermostat_repository.dart
+++ b/app/lib/features/thermostats/data/thermostat_repository.dart
@@ -127,8 +127,9 @@ class ThermostatRepository {
             ? drift.Value(fetchedAt)
             : const drift.Value.absent(),
         etag: etag != null ? drift.Value(etag) : const drift.Value.absent(),
-        statusMessage:
-            message != null ? drift.Value(message) : const drift.Value.absent(),
+        statusMessage: message != null
+            ? drift.Value(message)
+            : const drift.Value.absent(),
         createdAt: const drift.Value.absent(),
         updatedAt: drift.Value(now),
       ),

--- a/app/lib/features/thermostats/data/thermostat_repository.dart
+++ b/app/lib/features/thermostats/data/thermostat_repository.dart
@@ -113,6 +113,7 @@ class ThermostatRepository {
     double? valueC,
     DateTime? fetchedAt,
     String? etag,
+    String? message,
   }) async {
     final now = DateTime.now().toUtc();
     await _database.upsertThermostatState(
@@ -126,6 +127,8 @@ class ThermostatRepository {
             ? drift.Value(fetchedAt)
             : const drift.Value.absent(),
         etag: etag != null ? drift.Value(etag) : const drift.Value.absent(),
+        statusMessage:
+            message != null ? drift.Value(message) : const drift.Value.absent(),
         createdAt: const drift.Value.absent(),
         updatedAt: drift.Value(now),
       ),

--- a/app/lib/features/thermostats/data/thermostat_service.dart
+++ b/app/lib/features/thermostats/data/thermostat_service.dart
@@ -27,6 +27,7 @@ class ThermostatService {
       valueC: result.valueC,
       fetchedAt: result.fetchedAt,
       etag: result.etag,
+      message: 'Fetched ${result.valueC.toStringAsFixed(1)}°C',
     );
     return saved;
   }
@@ -48,6 +49,7 @@ class ThermostatService {
       valueC: result.valueC,
       fetchedAt: result.fetchedAt,
       etag: result.etag,
+      message: 'Fetched ${result.valueC.toStringAsFixed(1)}°C',
     );
     return updated;
   }

--- a/app/lib/features/thermostats/models/thermostat.dart
+++ b/app/lib/features/thermostats/models/thermostat.dart
@@ -18,7 +18,7 @@ class Thermostat {
 
   final String id;
   final String name;
-  final String rawUrl;
+  final String rawUrl; // Holds the Gist ID (API-backed)
   final double minC;
   final double maxC;
   final bool hysteresisEnabled;
@@ -67,7 +67,7 @@ class Thermostat {
 class ThermostatDraft {
   ThermostatDraft({
     required this.name,
-    required this.rawUrl,
+    required this.rawUrl, // Gist ID only
     required this.minC,
     required this.maxC,
   });
@@ -135,18 +135,14 @@ class ThermostatValidator {
       );
     }
 
-    final url = draft.rawUrl.trim();
-    final parsed = Uri.tryParse(url);
-    final hasValidScheme = parsed?.scheme == 'https';
-    if (url.isEmpty ||
-        parsed == null ||
-        !parsed.isAbsolute ||
-        parsed.host.isEmpty ||
-        !hasValidScheme) {
+    final input = draft.rawUrl.trim();
+    final gistIdPattern = RegExp(r'^[0-9a-fA-F]{32,40}$');
+    final looksLikeGistId = gistIdPattern.hasMatch(input);
+    if (input.isEmpty || !looksLikeGistId) {
       errors.add(
         ThermostatValidationError(
           field: ThermostatValidationField.rawUrl,
-          message: 'Provide a valid HTTPS raw URL.',
+          message: 'Enter a valid GitHub Gist ID.',
         ),
       );
     }

--- a/app/lib/features/thermostats/models/thermostat_state.dart
+++ b/app/lib/features/thermostats/models/thermostat_state.dart
@@ -11,6 +11,7 @@ class ThermostatState {
     this.lastValueC,
     this.lastFetchedAt,
     this.etag,
+    this.statusMessage,
     required this.createdAt,
     required this.updatedAt,
   });
@@ -20,6 +21,7 @@ class ThermostatState {
   final double? lastValueC;
   final DateTime? lastFetchedAt;
   final String? etag;
+  final String? statusMessage;
   final DateTime createdAt;
   final DateTime updatedAt;
 
@@ -30,6 +32,7 @@ class ThermostatState {
       lastValueC: entry.lastValueC,
       lastFetchedAt: entry.lastFetchedAt,
       etag: entry.etag,
+      statusMessage: entry.statusMessage,
       createdAt: entry.createdAt,
       updatedAt: entry.updatedAt,
     );
@@ -40,6 +43,7 @@ class ThermostatState {
     double? lastValueC,
     DateTime? lastFetchedAt,
     String? etag,
+    String? statusMessage,
     DateTime? updatedAt,
   }) {
     return ThermostatState(
@@ -48,6 +52,7 @@ class ThermostatState {
       lastValueC: lastValueC ?? this.lastValueC,
       lastFetchedAt: lastFetchedAt ?? this.lastFetchedAt,
       etag: etag ?? this.etag,
+      statusMessage: statusMessage ?? this.statusMessage,
       createdAt: createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
     );

--- a/app/lib/features/thermostats/models/thermostat_state.dart
+++ b/app/lib/features/thermostats/models/thermostat_state.dart
@@ -30,11 +30,11 @@ class ThermostatState {
       thermostatId: entry.thermostatId,
       status: ThermostatReadingStatusX.fromName(entry.lastStatus),
       lastValueC: entry.lastValueC,
-      lastFetchedAt: entry.lastFetchedAt,
+      lastFetchedAt: entry.lastFetchedAt?.toUtc(),
       etag: entry.etag,
       statusMessage: entry.statusMessage,
-      createdAt: entry.createdAt,
-      updatedAt: entry.updatedAt,
+      createdAt: entry.createdAt.toUtc(),
+      updatedAt: entry.updatedAt.toUtc(),
     );
   }
 

--- a/app/lib/features/thermostats/widgets/thermostat_card.dart
+++ b/app/lib/features/thermostats/widgets/thermostat_card.dart
@@ -130,8 +130,7 @@ class _LastSeenStatus extends StatelessWidget {
         final base = value != null
             ? '${value.toStringAsFixed(1)}°C • Updated $relative'
             : 'Updated $relative';
-        statusText =
-            message != null ? '$message • Updated $relative' : base;
+        statusText = message != null ? '$message • Updated $relative' : base;
         break;
       case ThermostatReadingStatus.networkError:
         final base = message ?? 'Last attempt failed: network error';

--- a/app/lib/features/thermostats/widgets/thermostat_card.dart
+++ b/app/lib/features/thermostats/widgets/thermostat_card.dart
@@ -118,24 +118,43 @@ class _LastSeenStatus extends StatelessWidget {
     final fetchedAt = state!.lastFetchedAt!;
     final value = state!.lastValueC;
     final status = state!.status;
+    final message = state!.statusMessage;
     final now = DateTime.now().toUtc();
     final difference = now.difference(fetchedAt);
     final relative = _formatRelativeDuration(difference);
 
-    final statusText = switch (status) {
-      ThermostatReadingStatus.ok =>
-        value != null
+    String statusText;
+    var isError = false;
+    switch (status) {
+      case ThermostatReadingStatus.ok:
+        final base = value != null
             ? '${value.toStringAsFixed(1)}°C • Updated $relative'
-            : 'Updated $relative',
-      ThermostatReadingStatus.networkError =>
-        'Last attempt failed: network error',
-      ThermostatReadingStatus.httpError => 'Last attempt failed: server error',
-      ThermostatReadingStatus.parseError =>
-        'Last attempt failed: invalid payload',
-      ThermostatReadingStatus.unknown => 'Last seen $relative',
-    };
-
-    final isError = status != ThermostatReadingStatus.ok;
+            : 'Updated $relative';
+        statusText =
+            message != null ? '$message • Updated $relative' : base;
+        break;
+      case ThermostatReadingStatus.networkError:
+        final base = message ?? 'Last attempt failed: network error';
+        statusText = '$base • Checked $relative';
+        isError = true;
+        break;
+      case ThermostatReadingStatus.httpError:
+        final base = message ?? 'Last attempt failed: server error';
+        statusText = '$base • Checked $relative';
+        isError = true;
+        break;
+      case ThermostatReadingStatus.parseError:
+        final base = message ?? 'Last attempt failed: invalid payload';
+        statusText = '$base • Checked $relative';
+        isError = true;
+        break;
+      case ThermostatReadingStatus.unknown:
+        statusText = message != null
+            ? '$message • Checked $relative'
+            : 'Last seen $relative';
+        isError = true;
+        break;
+    }
 
     return Text(
       statusText,

--- a/app/lib/features/thermostats/widgets/thermostat_form_dialog.dart
+++ b/app/lib/features/thermostats/widgets/thermostat_form_dialog.dart
@@ -179,15 +179,15 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
               TextFormField(
                 controller: _urlController,
                 decoration: InputDecoration(
-                  labelText: 'Raw URL',
-                  helperText: 'Use the HTTPS raw link to your Gist.',
+                  labelText: 'Gist ID',
+                  helperText: 'Enter the GitHub Gist ID (hex).',
                   errorText: _fieldErrors[ThermostatValidationField.rawUrl],
                 ),
-                keyboardType: TextInputType.url,
+                keyboardType: TextInputType.text,
                 enabled: !_isSubmitting,
                 validator: (value) {
                   if (value == null || value.trim().isEmpty) {
-                    return 'Enter a raw URL.';
+                    return 'Enter a Gist ID.';
                   }
                   return null;
                 },

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -2,7 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app.dart';
+import 'core/background/thermostat_monitor.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  try {
+    await initializeBackgroundMonitoring();
+  } catch (error, stackTrace) {
+    debugPrint('Failed to initialize background monitoring: $error');
+    debugPrint('$stackTrace');
+  }
   runApp(const ProviderScope(child: FarmCtlApp()));
 }

--- a/app/test/unit/thermostat_client_test.dart
+++ b/app/test/unit/thermostat_client_test.dart
@@ -25,34 +25,56 @@ class _FakeAdapter implements HttpClientAdapter {
 }
 
 void main() {
-  test('fetchCurrent returns parsed temperature', () async {
+  test('fetchCurrent returns parsed temperature (Gist API)', () async {
     final dio = Dio()
       ..httpClientAdapter = _FakeAdapter((options) async {
-        expect(options.headers[HttpHeaders.acceptHeader], 'text/plain');
-        return ResponseBody.fromString('Temperature: 12.5 C', 200);
+        if (options.path.contains('/gists/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')) {
+          expect(
+            options.headers[HttpHeaders.acceptHeader],
+            'application/vnd.github+json',
+          );
+          return ResponseBody.fromString(
+            '{"files": {"thermostat.txt": {"filename": "thermostat.txt", "truncated": false, "content": "Temperature: 12.5 C"}}}',
+            200,
+            headers: {
+              Headers.contentTypeHeader: [ContentType.json.mimeType],
+            },
+          );
+        }
+        return ResponseBody.fromString('not found', 404);
       });
 
     final client = ThermostatHttpClient(dio: dio);
 
-    final result = await client.fetchCurrent('https://example.com/raw');
+    final result = await client.fetchCurrent(
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    );
 
     expect(result.valueC, closeTo(12.5, 0.0001));
-    expect(result.etag, isNull);
     expect(
       DateTime.now().difference(result.fetchedAt).inSeconds.abs(),
       lessThan(5),
     );
   });
 
-  test('fetchCurrent throws on parse error', () async {
+  test('fetchCurrent throws on parse error (Gist API)', () async {
     final dio = Dio()
-      ..httpClientAdapter = _FakeAdapter(
-        (options) async => ResponseBody.fromString('invalid payload', 200),
-      );
+      ..httpClientAdapter = _FakeAdapter((options) async {
+        if (options.path.contains('/gists/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')) {
+          return ResponseBody.fromString(
+            '{"files": {"thermostat.txt": {"filename": "thermostat.txt", "truncated": false, "content": "invalid payload"}}}',
+            200,
+            headers: {
+              Headers.contentTypeHeader: [ContentType.json.mimeType],
+            },
+          );
+        }
+        return ResponseBody.fromString('not found', 404);
+      });
     final client = ThermostatHttpClient(dio: dio);
 
     expect(
-      () => client.fetchCurrent('https://example.com/raw'),
+      () => client.fetchCurrent('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'),
       throwsA(
         isA<ThermostatFetchException>().having(
           (error) => error.status,
@@ -63,15 +85,18 @@ void main() {
     );
   });
 
-  test('fetchCurrent throws on http error', () async {
+  test('fetchCurrent throws on http error (Gist API)', () async {
     final dio = Dio()
-      ..httpClientAdapter = _FakeAdapter(
-        (options) async => ResponseBody.fromString('not found', 404),
-      );
+      ..httpClientAdapter = _FakeAdapter((options) async {
+        if (options.path.contains('/gists/cccccccccccccccccccccccccccccccc')) {
+          return ResponseBody.fromString('not found', 404);
+        }
+        return ResponseBody.fromString('not found', 404);
+      });
     final client = ThermostatHttpClient(dio: dio);
 
     expect(
-      () => client.fetchCurrent('https://example.com/raw'),
+      () => client.fetchCurrent('cccccccccccccccccccccccccccccccc'),
       throwsA(
         isA<ThermostatFetchException>().having(
           (error) => error.status,
@@ -82,7 +107,7 @@ void main() {
     );
   });
 
-  test('fetchCurrent throws on network error', () async {
+  test('fetchCurrent throws on network error (Gist API)', () async {
     final dio = Dio()
       ..httpClientAdapter = _FakeAdapter((options) async {
         throw DioException(
@@ -94,7 +119,7 @@ void main() {
     final client = ThermostatHttpClient(dio: dio);
 
     expect(
-      () => client.fetchCurrent('https://example.com/raw'),
+      () => client.fetchCurrent('dddddddddddddddddddddddddddddddd'),
       throwsA(
         isA<ThermostatFetchException>().having(
           (error) => error.status,

--- a/app/test/unit/thermostat_monitor_runner_test.dart
+++ b/app/test/unit/thermostat_monitor_runner_test.dart
@@ -1,0 +1,106 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:farmctl/core/background/thermostat_monitor.dart';
+import 'package:farmctl/features/thermostats/data/thermostat_client.dart';
+import 'package:farmctl/features/thermostats/data/thermostat_database.dart';
+import 'package:farmctl/features/thermostats/data/thermostat_repository.dart';
+import 'package:farmctl/features/thermostats/models/thermostat.dart';
+import 'package:farmctl/features/thermostats/models/thermostat_state.dart';
+
+class _FakeNetwork implements ThermostatNetworkDataSource {
+  _FakeNetwork(this._result);
+
+  ThermostatFetchSuccess? _result;
+  ThermostatFetchException? _exception;
+
+  @override
+  Future<ThermostatFetchSuccess> fetchCurrent(String url) async {
+    if (_exception != null) {
+      throw _exception!;
+    }
+    final result = _result;
+    if (result == null) {
+      throw StateError('No result configured');
+    }
+    return result;
+  }
+}
+
+void main() {
+  late ThermostatDatabase database;
+  late ThermostatRepository repository;
+  late _FakeNetwork network;
+
+  setUp(() {
+    database = ThermostatDatabase.forTesting(NativeDatabase.memory());
+    repository = ThermostatRepository(database);
+    network = _FakeNetwork(
+      ThermostatFetchSuccess(
+        valueC: 21.5,
+        fetchedAt: DateTime.utc(2025, 1, 1, 12),
+        etag: 'etag',
+      ),
+    );
+  });
+
+  tearDown(() async {
+    await database.close();
+  });
+
+  test('run updates state on success', () async {
+    final thermostat = await repository.create(
+      ThermostatDraft(
+        name: 'Barn',
+        rawUrl: 'https://example.com/barn',
+        minC: 0,
+        maxC: 20,
+      ),
+    );
+
+    final runner = ThermostatMonitorRunner(
+      repository: repository,
+      network: network,
+      clock: () => DateTime.utc(2025, 1, 1, 13),
+    );
+
+    await runner.run();
+
+    final state = await repository.loadState(thermostat.id);
+    expect(state, isNotNull);
+    expect(state!.status, ThermostatReadingStatus.ok);
+    expect(state.lastValueC, 21.5);
+    expect(state.statusMessage, 'Fetched 21.5°C');
+    expect(state.etag, 'etag');
+  });
+
+  test('run records failure details', () async {
+    final thermostat = await repository.create(
+      ThermostatDraft(
+        name: 'Greenhouse',
+        rawUrl: 'https://example.com/greenhouse',
+        minC: 2,
+        maxC: 12,
+      ),
+    );
+
+    network._exception = const ThermostatFetchException(
+      status: ThermostatReadingStatus.networkError,
+      message: 'network down',
+    );
+
+    final runner = ThermostatMonitorRunner(
+      repository: repository,
+      network: network,
+      clock: () => DateTime.utc(2025, 1, 1, 13),
+    );
+
+    await runner.run();
+
+    final state = await repository.loadState(thermostat.id);
+    expect(state, isNotNull);
+    expect(state!.status, ThermostatReadingStatus.networkError);
+    expect(state.statusMessage, 'network down');
+    expect(state.lastFetchedAt, DateTime.utc(2025, 1, 1, 13));
+  });
+}

--- a/app/test/unit/thermostat_monitor_runner_test.dart
+++ b/app/test/unit/thermostat_monitor_runner_test.dart
@@ -11,7 +11,7 @@ import 'package:farmctl/features/thermostats/models/thermostat_state.dart';
 class _FakeNetwork implements ThermostatNetworkDataSource {
   _FakeNetwork(this._result);
 
-  ThermostatFetchSuccess? _result;
+  final ThermostatFetchSuccess? _result;
   ThermostatFetchException? _exception;
 
   @override

--- a/app/test/unit/thermostat_monitor_runner_test.dart
+++ b/app/test/unit/thermostat_monitor_runner_test.dart
@@ -52,7 +52,7 @@ void main() {
     final thermostat = await repository.create(
       ThermostatDraft(
         name: 'Barn',
-        rawUrl: 'https://example.com/barn',
+        rawUrl: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
         minC: 0,
         maxC: 20,
       ),
@@ -78,7 +78,7 @@ void main() {
     final thermostat = await repository.create(
       ThermostatDraft(
         name: 'Greenhouse',
-        rawUrl: 'https://example.com/greenhouse',
+        rawUrl: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
         minC: 2,
         maxC: 12,
       ),

--- a/app/test/unit/thermostat_repository_test.dart
+++ b/app/test/unit/thermostat_repository_test.dart
@@ -22,7 +22,7 @@ void main() {
   test('create stores and returns thermostat', () async {
     final draft = ThermostatDraft(
       name: 'Barn',
-      rawUrl: 'https://example.com/barn',
+      rawUrl: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       minC: 0,
       maxC: 20,
     );
@@ -39,7 +39,7 @@ void main() {
     final original = await repository.create(
       ThermostatDraft(
         name: 'Greenhouse',
-        rawUrl: 'https://example.com/greenhouse',
+        rawUrl: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
         minC: 4,
         maxC: 12,
       ),
@@ -49,14 +49,14 @@ void main() {
       original,
       ThermostatDraft(
         name: 'Greenhouse West',
-        rawUrl: 'https://example.com/greenhouse-west',
+        rawUrl: 'cccccccccccccccccccccccccccccccc',
         minC: 3,
         maxC: 11,
       ),
     );
 
     expect(updated.name, 'Greenhouse West');
-    expect(updated.rawUrl, 'https://example.com/greenhouse-west');
+    expect(updated.rawUrl, 'cccccccccccccccccccccccccccccccc');
     expect(updated.minC, 3);
     expect(updated.maxC, 11);
   });
@@ -65,7 +65,7 @@ void main() {
     final thermostat = await repository.create(
       ThermostatDraft(
         name: 'Propagation',
-        rawUrl: 'https://example.com/propagation',
+        rawUrl: 'ffffffffffffffffffffffffffffffff',
         minC: 6,
         maxC: 18,
       ),
@@ -91,7 +91,7 @@ void main() {
   test('create throws on invalid data', () async {
     final draft = ThermostatDraft(
       name: '',
-      rawUrl: 'not a url',
+      rawUrl: 'not-a-gist-id',
       minC: 0,
       maxC: -1,
     );
@@ -106,7 +106,7 @@ void main() {
     final thermostat = await repository.create(
       ThermostatDraft(
         name: 'Nursery',
-        rawUrl: 'https://example.com/nursery',
+        rawUrl: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
         minC: 5,
         maxC: 18,
       ),

--- a/app/test/unit/thermostat_repository_test.dart
+++ b/app/test/unit/thermostat_repository_test.dart
@@ -77,6 +77,7 @@ void main() {
       valueC: 12.3,
       fetchedAt: DateTime.utc(2025, 1, 1, 12),
       etag: 'etag',
+      message: 'Fetched 12.3°C',
     );
 
     await repository.delete(thermostat.id);
@@ -117,12 +118,14 @@ void main() {
       valueC: 9.5,
       fetchedAt: DateTime.utc(2025, 1, 2, 8),
       etag: 'tag',
+      message: 'Fetched 9.5°C',
     );
 
     var state = await repository.loadState(thermostat.id);
     expect(state, isNotNull);
     expect(state!.status, ThermostatReadingStatus.ok);
     expect(state.lastValueC, 9.5);
+    expect(state.statusMessage, 'Fetched 9.5°C');
 
     await repository.saveState(
       thermostatId: thermostat.id,
@@ -130,11 +133,13 @@ void main() {
       valueC: null,
       fetchedAt: DateTime.utc(2025, 1, 2, 9),
       etag: null,
+      message: 'Failed with status 500',
     );
 
     state = await repository.loadState(thermostat.id);
     expect(state, isNotNull);
     expect(state!.status, ThermostatReadingStatus.httpError);
     expect(state.lastValueC, 9.5);
+    expect(state.statusMessage, 'Failed with status 500');
   });
 }

--- a/app/test/unit/thermostat_service_test.dart
+++ b/app/test/unit/thermostat_service_test.dart
@@ -54,7 +54,7 @@ void main() {
     final created = await service.createAndTest(
       ThermostatDraft(
         name: 'Barn',
-        rawUrl: 'https://example.com/barn',
+        rawUrl: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
         minC: 0,
         maxC: 20,
       ),
@@ -74,7 +74,7 @@ void main() {
     final initial = await service.createAndTest(
       ThermostatDraft(
         name: 'Greenhouse',
-        rawUrl: 'https://example.com/greenhouse',
+        rawUrl: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
         minC: 4,
         maxC: 12,
       ),
@@ -90,7 +90,7 @@ void main() {
       initial,
       ThermostatDraft(
         name: 'Greenhouse West',
-        rawUrl: 'https://example.com/greenhouse-west',
+        rawUrl: 'cccccccccccccccccccccccccccccccc',
         minC: 3,
         maxC: 11,
       ),
@@ -113,7 +113,7 @@ void main() {
       () => service.createAndTest(
         ThermostatDraft(
           name: 'Faulty',
-          rawUrl: 'https://example.com/faulty',
+          rawUrl: 'dddddddddddddddddddddddddddddddd',
           minC: 0,
           maxC: 10,
         ),

--- a/app/test/unit/thermostat_service_test.dart
+++ b/app/test/unit/thermostat_service_test.dart
@@ -67,6 +67,7 @@ void main() {
     expect(state, isNotNull);
     expect(state!.status, ThermostatReadingStatus.ok);
     expect(state.lastValueC, 14.2);
+    expect(state.statusMessage, 'Fetched 14.2°C');
   });
 
   test('updateAndTest updates thermostat and state', () async {
@@ -99,6 +100,7 @@ void main() {
     final state = await repository.loadState(updated.id);
     expect(state, isNotNull);
     expect(state!.lastValueC, 9.0);
+    expect(state.statusMessage, 'Fetched 9.0°C');
   });
 
   test('createAndTest rethrows fetch errors', () async {

--- a/app/test/unit/thermostat_validator_test.dart
+++ b/app/test/unit/thermostat_validator_test.dart
@@ -7,7 +7,7 @@ void main() {
     test('accepts valid draft', () {
       final draft = ThermostatDraft(
         name: 'Greenhouse',
-        rawUrl: 'https://example.com/raw.txt',
+        rawUrl: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
         minC: 2,
         maxC: 10,
       );
@@ -38,10 +38,10 @@ void main() {
       );
     });
 
-    test('rejects invalid url', () {
+    test('rejects invalid gist id', () {
       final draft = ThermostatDraft(
         name: 'Greenhouse',
-        rawUrl: 'http://example.com',
+        rawUrl: 'not-a-gist-id',
         minC: 2,
         maxC: 10,
       );
@@ -49,20 +49,18 @@ void main() {
       final result = ThermostatValidator.validate(draft);
 
       expect(result.isValid, isFalse);
-      expect(
-        result.errors
-            .firstWhere(
-              (error) => error.field == ThermostatValidationField.rawUrl,
-            )
-            .message,
-        contains('HTTPS'),
-      );
+      final msg = result.errors
+          .firstWhere(
+            (error) => error.field == ThermostatValidationField.rawUrl,
+          )
+          .message;
+      expect(msg, contains('Gist ID'));
     });
 
     test('rejects out-of-bounds temperatures', () {
       final draft = ThermostatDraft(
         name: 'Greenhouse',
-        rawUrl: 'https://example.com',
+        rawUrl: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
         minC: -100,
         maxC: 500,
       );
@@ -83,7 +81,7 @@ void main() {
     test('rejects inverted range', () {
       final draft = ThermostatDraft(
         name: 'Greenhouse',
-        rawUrl: 'https://example.com',
+        rawUrl: 'cccccccccccccccccccccccccccccccc',
         minC: 12,
         maxC: 10,
       );

--- a/docs/ImplementationPlan.md
+++ b/docs/ImplementationPlan.md
@@ -11,9 +11,9 @@ This plan translates the executable specification into a concrete Flutter applic
    - Entities (Thermostat, Reading, AlertConfig, ThermostatState) and use-cases (AddThermostat, EditThermostat, RemoveThermostat, FetchCurrent, BuildHistory, EvaluateRange, ScheduleNext, RaiseAlarm, AcknowledgeAlarm).
    - Validation rules, hysteresis logic, rate limiting, and scheduler math. Depends only on abstractions: Clock, Net, Audio, Scheduler, Store.
 3. Data
-   - Repositories and data sources:
-     - dio HTTP client with retries/backoff/jitter and ETag handling.
-     - GitHub Gist API wrapper for revisions/history. Central parser using the spec regex.
+- Repositories and data sources:
+  - dio HTTP client with retries/backoff/jitter and ETag handling.
+  - GitHub Gist API wrapper for current readings and revisions/history (by Gist ID). Central parser using the spec regex.
      - drift (SQLite) for persistence with indexes and migrations.
    - DTOs/mappers to domain entities; ETag cache per thermostat.
 4. System Integration (Flutter-first)
@@ -41,7 +41,7 @@ Dependency direction: Presentation -> Domain -> Data. System interacts with Doma
 Aligns with Spec Section 5. Field names are explicit and indexed where needed.
 
 - thermostats
-  - id (TEXT UUID PK), name (TEXT), rawUrl (TEXT),
+  - id (TEXT UUID PK), name (TEXT), gistId (TEXT),
   - minC (REAL), maxC (REAL), hysteresisEnabled (BOOL),
   - monitoringEnabled (BOOL), createdAt (INTEGER TS), updatedAt (INTEGER TS)
 
@@ -82,22 +82,22 @@ Indexes: readings(thermostatId, observedAt DESC), thermostats(name), event_log(t
 ## 5. Networking & Caching Approach
 
 - HTTP via dio with policies:
-  - Headers: Accept: text/plain for raw; If-None-Match when ETag available.
+  - Current: `GET https://api.github.com/gists/{gistId}` with `Accept: application/vnd.github+json` and `User-Agent`; if `truncated` or `content` missing, fetch `raw_url` with `Accept: text/plain`.
   - Timeouts: connect 5s, read 10s. Retries: up to 2 with jittered exponential backoff.
-  - ETag cache per thermostat; handle 304 to avoid quota usage.
+  - ETag cache per thermostat; handle 304 where applicable.
 - Parsing: Single tolerant regex from spec; first match only; device receive time for current; revision commit timestamp for history.
 - History:
-  - GET /gists/{gist_id}/commits to list revisions, then fetch raw per sha.
+  - `GET /gists/{gistId}/commits` to list revisions; per revision, fetch target file `raw_url` and parse.
   - Pagination until requested range is filled; progressive rendering as data arrives.
 - Offline:
   - Cache last values in DB; surface "Updated X min ago".
-  - Status-specific error handling (network, parse, auth). Banner guidance for rate limiting.
+  - Status-specific error handling (network, parse, auth, rate-limit). Banner guidance for rate limiting.
 
 ## 6. UI & Navigation
 
 - Bottom navigation with two tabs: Thermostats and Settings.
 - Thermostats list: cards show name, colored status (green OK, red Out of Range, yellow Error), last value with relative time, range pill, monitor toggle, overflow (Edit, View history, Remove); FAB to add.
-- Add/Edit thermostat: fields per spec; Test & Save performs live fetch/parse with inline errors; invalid save is blocked.
+- Add/Edit thermostat: fields per spec; Test & Save performs live fetch/parse via Gist ID with inline errors; invalid save is blocked.
 - Details: current panel (big value, range, last updated, Snooze/Silence); graph panel (1h/1d/1w/1m/1y/All) with pan/zoom/tooltips; diagnostics (last status + last 10 log lines).
 - Settings: poll interval slider, exact alarms toggle with rationale, pause-all durations; choose sound (system picker), vibrate, test alarm; rebuild history, export CSV; About.
 

--- a/docs/Spec.md
+++ b/docs/Spec.md
@@ -10,8 +10,8 @@
 
 **In-scope**
 
-* Manage multiple remote thermostats whose **current temperature** is read from **GitHub Gist raw URLs**.
-* Add/remove thermostats at runtime; each has its own **name**, **source URL**, and **operating range** (min/max in °C).
+* Manage multiple remote thermostats whose **current temperature** is read from **GitHub Gists via the GitHub Gist API** using a **Gist ID**.
+* Add/remove thermostats at runtime; each has its own **name**, **Gist ID**, and **operating range** (min/max in °C).
 * Background **watchdog** that continuously monitors sensors and triggers **audible alarms** (Android alarm-app-like behavior) when values go out of range.
 * Historical graphs over: **1h, 24h, 7d, 30d, 365d, all-time**, using **Gist revision history**.
 * Configurable alarm sound using **system sound picker** (alarms/tones/music).
@@ -29,9 +29,9 @@
 
 ## 2) Definitions & Assumptions
 
-* **Thermostat Source**: A public GitHub Gist *raw* URL that, when fetched, returns a **single-line** payload in English:
+* **Thermostat Source**: A public GitHub Gist addressed by **Gist ID**. The app fetches the Gist via the **GitHub Gist API** and reads a file whose content is a **single-line** payload in English:
   `Temperature: <float> C` (example: `Temperature: 8.13 C`).
-  Optional whitespace is allowed. Case-insensitive keys “Temperature” and “C” must be accepted.
+  Optional whitespace is allowed. Case-insensitive keys “Temperature” and “C” must be accepted. If the chosen file is reported as `truncated` by the API, the app fetches its `raw_url` to obtain the full text prior to parsing.
 * **History Source**: The Gist’s **revisions** list; each revision’s raw content is parsed as above; the revision’s **commit timestamp** is the sample time.
 * **Units**: Celsius only (UI can show °C symbol; no °F conversion).
 * **Sampling cadence**: Configurable polling (default: **every 5 minutes**) with jitter (±30 sec) to avoid thundering herd and rate limits.
@@ -46,15 +46,15 @@
 
 * **Add thermostat**
 
-  * Inputs: `name` (1–40 chars), `rawUrl` (https URL), `minC` (float), `maxC` (float).
+  * Inputs: `name` (1–40 chars), `gistId` (hex, 32–40 chars), `minC` (float), `maxC` (float).
   * Validation:
 
-    * `rawUrl` must be HTTPS and match GitHub Gist raw pattern or be a valid HTTPS URL that returns a temperature line (allow general HTTPS to avoid over-fitting).
-    * On save, app **tests** the URL once: HTTP 200 within 10s, parse temperature; if parse fails → show blocking error and **do not** persist.
+    * `gistId` must be a valid GitHub Gist identifier (hex, 32–40 chars) referencing a public Gist.
+    * On save, app **tests** the Gist via the API once: HTTP 200 within 10s, parse temperature from selected file (preferring names containing “thermostat” or `.txt`); if parse fails → show blocking error and **do not** persist.
     * `minC < maxC` and both within **[-80.0, 200.0]**.
 * **Edit thermostat**
 
-  * All fields editable; URL re-validated on change.
+  * All fields editable; Gist ID re-validated on change.
 * **Remove thermostat**
 
   * Immediate, with confirmation. Removes local cached history for that thermostat.
@@ -67,7 +67,7 @@
 
 ### 3.3 Read Current Temperature
 
-* **Fetch** using HTTP GET to the configured raw URL.
+* **Fetch** using HTTP GET to the **GitHub Gist API** for the configured Gist ID; if the selected file is `truncated`, fetch its `raw_url`.
 * **Parse** tolerant regex (case-insensitive, spaces optional):
   `^.*?Temperature\s*:\s*([-+]?\d+(?:\.\d+)?)\s*C.*$`
 * **Timestamp**: server time is not trusted; use **device receive time** for current reading, **revision timestamp** for history.
@@ -107,7 +107,7 @@
 
 ### 3.6 Global & Per-Thermostat Controls
 
-* **Per-thermostat**: enable/disable monitoring; edit name/URL/range; open details (current value, history, last error).
+* **Per-thermostat**: enable/disable monitoring; edit name/Gist ID/range; open details (current value, history, last error).
 * **Global**: pause all monitoring for a duration (e.g., 1h, 8h, until next day).
 
 ### 3.7 Error Handling & Health
@@ -146,7 +146,7 @@
 Use a relational store (e.g., SQLite) with the following conceptual schema:
 
 * `Thermostat`
-  `id (UUID)`, `name (TEXT)`, `rawUrl (TEXT)`,
+  `id (UUID)`, `name (TEXT)`, `gistId (TEXT)`,
   `minC (REAL)`, `maxC (REAL)`, `hysteresisEnabled (BOOL)`,
   `monitoringEnabled (BOOL)`, `createdAt (TS)`, `updatedAt (TS)`
 
@@ -175,12 +175,14 @@ Use a relational store (e.g., SQLite) with the following conceptual schema:
 
 ### 6.1 Current Reading Contract
 
-* **Input**: `rawUrl` (HTTPS).
-* **Request headers**: `Accept: text/plain`, `If-None-Match` (use ETag when available).
+* **Input**: `gistId` (hex, 32–40).
+* **API request**: `GET https://api.github.com/gists/{gistId}`
+* **Request headers**: `Accept: application/vnd.github+json`, `User-Agent: farmctl/<version>`.
+* If the selected file in the response has `truncated: true` or `content` is absent, fetch its `raw_url` with `Accept: text/plain`.
 * **Timeout**: connect 5s, read 10s.
 * **Retries**: up to 2 with backoff.
 
-**Expected Response (examples)**
+**Expected File Content (examples)**
 
 ```
 Temperature: 8.13 C
@@ -192,9 +194,9 @@ temperature: 12.0 c
 
 ### 6.2 History Contract
 
-* **List revisions** for the Gist containing the target file; for each revision:
+* **List revisions** for the Gist via the API; for each revision:
 
-  * Construct raw URL for that revision.
+  * Obtain the `raw_url` of the target file at that revision.
   * Fetch and parse as above.
   * Use **revision commit timestamp** as `observedAt`.
 * **Pagination**: iterate until reaching the requested time range or page limit.
@@ -225,7 +227,7 @@ temperature: 12.0 c
 
 **B) Add/Edit Thermostat**
 
-* Fields: Name (text), URL (text), Min °C (numeric), Max °C (numeric), Hysteresis (switch), Monitoring (switch).
+* Fields: Name (text), Gist ID (text), Min °C (numeric), Max °C (numeric), Hysteresis (switch), Monitoring (switch).
 * “Test & Save” button (does a real fetch, shows parsed temp).
 * Validation errors inline under fields.
 
@@ -287,7 +289,7 @@ temperature: 12.0 c
 
 ## 10) Error Messages (Canonical)
 
-* URL invalid: “That doesn’t look like a valid HTTPS URL.”
+* Gist ID invalid: “That doesn’t look like a valid GitHub Gist ID.”
 * Fetch timeout: “Couldn’t reach the thermostat (timeout).”
 * HTTP error: “The server responded with <code>.”
 * Parse error: “Content didn’t include a ‘Temperature: … C’ line.”
@@ -309,7 +311,7 @@ All error strings must be centralized for localization.
 
 ### 11.2 Integration/Instrumentation Tests
 
-* **Add/Edit flow**: enter URL, test & save, verify card shows value.
+* **Add/Edit flow**: enter Gist ID, test & save, verify card shows value.
 * **History graph**: mock revisions list with 10k points; verify downsampling & tooltips.
 * **Alarm surface**: simulate out-of-range; verify full-screen UI, actions (snooze/silence), sound playback via mockable audio layer.
 * **Reboot persistence**: enable monitoring, simulate reboot, verify reschedule.
@@ -399,7 +401,7 @@ Display clear rationale dialogs where needed.
 
 ## 18) Acceptance Criteria
 
-1. Can add a thermostat with the provided example URL; app shows a parsed temperature within 10s.
+1. Can add a thermostat with the provided example Gist ID; app shows a parsed temperature within 10s.
 2. Can configure min/max; when the value crosses the threshold, an audible full-screen alarm appears, with snooze/silence actions that work.
 3. History graph populates for “All” by walking revisions and displays tooltips with correct timestamps.
 4. After device reboot, monitoring continues without user opening the app.


### PR DESCRIPTION
## Summary
- add a WorkManager-backed thermostat monitor that runs in the background, updates cached state, and posts a foreground notification while running
- extend the thermostat state schema to persist human-readable status messages and display them on the thermostat cards
- cover the monitor runner with unit tests and update existing tests for the new status messaging

## Testing
- `flutter test` *(fails: flutter command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ec38a6bf2883259aeaaf30f25f2edc