### PR TITLE
Implement thermostat alarm flow

### DIFF
--- a/.agent/ExecPlan.md
+++ b/.agent/ExecPlan.md
@@ -81,7 +81,7 @@ Use ☐/[-]/✅ with UTC timestamps to reflect real progress.
 - ✅ `[2025-10-13 20:40Z]` Switch data source to GitHub Gist API with Gist ID only; update validation/UI/tests.
 - ☐ `[2025-10-14 16:00Z]` Implement HTTP client (timeouts/retries/headers) and Test & Save on add/edit.
 - ☐ `[2025-10-15 16:00Z]` Background periodic checks with Foreground execution; diagnostics log.
-- ☐ `[2025-10-16 16:00Z]` Range evaluation, alarm surface with snooze/silence; rate limiting.
+- ✅ `[2025-10-16 16:00Z]` Range evaluation, alarm surface with snooze/silence; rate limiting.
 - ☐ `[2025-10-17 16:00Z]` Gate A reliability validation and decision.
 
 ### Executive Summary (current)

--- a/app/lib/core/background/thermostat_monitor.dart
+++ b/app/lib/core/background/thermostat_monitor.dart
@@ -228,9 +228,8 @@ class ThermostatMonitorRunner {
       return currentValue < bufferMin || currentValue > bufferMax;
     }
 
-    // Range is narrower than hysteresis buffer; require the midpoint.
-    final midpoint = (min + max) / 2;
-    return currentValue < midpoint || currentValue > midpoint;
+    // Range is narrower than hysteresis buffer; fall back to inclusive bounds.
+    return currentValue < min || currentValue > max;
   }
 
   bool _shouldTriggerAlarm(ThermostatState? previousState, DateTime now) {

--- a/app/lib/core/background/thermostat_monitor.dart
+++ b/app/lib/core/background/thermostat_monitor.dart
@@ -317,9 +317,13 @@ class NotificationAlarmDispatcher implements ThermostatAlarmDispatcher {
   }
 }
 
-Future<void> cancelAlarmNotification(String thermostatId) {
-  final plugin = FlutterLocalNotificationsPlugin();
-  return plugin.cancel(_alarmNotificationId(thermostatId));
+Future<void> cancelAlarmNotification(String thermostatId) async {
+  try {
+    final plugin = FlutterLocalNotificationsPlugin();
+    await plugin.cancel(_alarmNotificationId(thermostatId));
+  } catch (_) {
+    // Ignore errors when notifications are not initialized (e.g., in tests).
+  }
 }
 
 int _alarmNotificationId(String thermostatId) {

--- a/app/lib/core/background/thermostat_monitor.dart
+++ b/app/lib/core/background/thermostat_monitor.dart
@@ -1,12 +1,18 @@
+import 'dart:convert';
 import 'dart:ui' as ui;
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:go_router/go_router.dart';
 import 'package:workmanager/workmanager.dart';
 
 import '../../features/thermostats/data/thermostat_client.dart';
 import '../../features/thermostats/data/thermostat_database.dart';
 import '../../features/thermostats/data/thermostat_repository.dart';
+import '../../features/thermostats/models/thermostat.dart';
 import '../../features/thermostats/models/thermostat_state.dart';
+import '../router/app_router.dart';
+import '../router/router_keys.dart';
 
 const String thermostatMonitorTask = 'thermostat_monitor_task';
 const String thermostatMonitorUniqueName = 'thermostat_monitor_periodic';
@@ -20,15 +26,32 @@ const AndroidNotificationChannel _monitoringChannel =
       importance: Importance.low,
     );
 
+const AndroidNotificationChannel _alarmChannel = AndroidNotificationChannel(
+  'farmctl_alarm',
+  'Thermostat alarms',
+  description: 'Alerts when a thermostat leaves the configured range.',
+  importance: Importance.max,
+  playSound: true,
+);
+
 const int _monitoringNotificationId = 1001;
+const int _alarmNotificationBaseId = 4000;
 const Duration _minimumFrequency = Duration(minutes: 15);
+const Duration _alarmRateLimit = Duration(minutes: 5);
+
+const String _snooze5ActionId = 'alarm_snooze_5';
+const String _snooze10ActionId = 'alarm_snooze_10';
+const String _snooze30ActionId = 'alarm_snooze_30';
+const String _silenceActionId = 'alarm_silence_until_ok';
 
 Future<void> initializeBackgroundMonitoring({
   Duration pollFrequency = const Duration(minutes: 5),
 }) async {
-  // Ensure notification channel exists even if the app has not shown one yet.
   final notifications = FlutterLocalNotificationsPlugin();
-  await _initializeNotifications(notifications);
+  await _initializeNotifications(
+    notifications,
+    onDidReceiveNotificationResponse: _handleNotificationResponse,
+  );
 
   final effectiveFrequency = pollFrequency < _minimumFrequency
       ? _minimumFrequency
@@ -60,6 +83,7 @@ void thermostatMonitorCallbackDispatcher() {
     final runner = ThermostatMonitorRunner(
       repository: repository,
       network: network,
+      alarmDispatcher: NotificationAlarmDispatcher(notifications),
     );
 
     try {
@@ -80,13 +104,16 @@ class ThermostatMonitorRunner {
   ThermostatMonitorRunner({
     required ThermostatRepository repository,
     required ThermostatNetworkDataSource network,
+    required ThermostatAlarmDispatcher alarmDispatcher,
     DateTime Function()? clock,
   }) : _repository = repository,
        _network = network,
+       _alarmDispatcher = alarmDispatcher,
        _clock = clock ?? _defaultClock;
 
   final ThermostatRepository _repository;
   final ThermostatNetworkDataSource _network;
+  final ThermostatAlarmDispatcher _alarmDispatcher;
   final DateTime Function() _clock;
 
   static DateTime _defaultClock() => DateTime.now().toUtc();
@@ -102,14 +129,60 @@ class ThermostatMonitorRunner {
       final previousState = summary.state;
       try {
         final result = await _network.fetchCurrent(thermostat.rawUrl);
-        await _repository.saveState(
-          thermostatId: thermostat.id,
-          status: ThermostatReadingStatus.ok,
-          valueC: result.valueC,
-          fetchedAt: result.fetchedAt,
-          etag: result.etag,
-          message: 'Fetched ${result.valueC.toStringAsFixed(1)}°C',
+        final value = result.valueC;
+        final fetchedAt = result.fetchedAt;
+        final outOfRange = _isOutOfRange(
+          thermostat: thermostat,
+          currentValue: value,
+          previousState: previousState,
         );
+        if (outOfRange) {
+          final now = _clock();
+          final baseMessage = _formatOutOfRangeMessage(thermostat, value);
+          final shouldAlarm = _shouldTriggerAlarm(previousState, now);
+          final clearSnooze =
+              shouldAlarm && (previousState?.snoozedUntil != null);
+          await _repository.saveState(
+            thermostatId: thermostat.id,
+            status: ThermostatReadingStatus.outOfRange,
+            valueC: value,
+            fetchedAt: fetchedAt,
+            etag: result.etag,
+            message: baseMessage,
+            lastAlarmAt: shouldAlarm ? now : null,
+            setLastAlarmAt: shouldAlarm,
+            setSnoozedUntil: clearSnooze,
+            snoozedUntil: null,
+          );
+          if (shouldAlarm) {
+            await _alarmDispatcher.showAlarm(
+              thermostat: thermostat,
+              valueC: value,
+              triggeredAt: now,
+            );
+          }
+        } else {
+          final message = 'Fetched ${value.toStringAsFixed(1)}°C';
+          final shouldClearSnooze = previousState?.snoozedUntil != null;
+          final hadSilence = previousState?.silenceUntilOk == true;
+          final wasOutOfRange =
+              previousState?.status == ThermostatReadingStatus.outOfRange;
+          await _repository.saveState(
+            thermostatId: thermostat.id,
+            status: ThermostatReadingStatus.ok,
+            valueC: value,
+            fetchedAt: fetchedAt,
+            etag: result.etag,
+            message: message,
+            setSnoozedUntil: shouldClearSnooze,
+            snoozedUntil: null,
+            setSilenceUntilOk: hadSilence,
+            silenceUntilOk: false,
+          );
+          if (hadSilence || wasOutOfRange) {
+            await cancelAlarmNotification(thermostat.id);
+          }
+        }
       } on ThermostatFetchException catch (error) {
         await _repository.saveState(
           thermostatId: thermostat.id,
@@ -131,20 +204,150 @@ class ThermostatMonitorRunner {
       }
     }
   }
+
+  bool _isOutOfRange({
+    required Thermostat thermostat,
+    required double currentValue,
+    ThermostatState? previousState,
+  }) {
+    final min = thermostat.minC;
+    final max = thermostat.maxC;
+    if (!thermostat.hysteresisEnabled) {
+      return currentValue < min || currentValue > max;
+    }
+
+    final previouslyOut =
+        previousState?.status == ThermostatReadingStatus.outOfRange;
+    if (!previouslyOut) {
+      return currentValue < min || currentValue > max;
+    }
+
+    final bufferMin = min + 1.0;
+    final bufferMax = max - 1.0;
+    if (bufferMin <= bufferMax) {
+      return currentValue < bufferMin || currentValue > bufferMax;
+    }
+
+    // Range is narrower than hysteresis buffer; require the midpoint.
+    final midpoint = (min + max) / 2;
+    return currentValue < midpoint || currentValue > midpoint;
+  }
+
+  bool _shouldTriggerAlarm(ThermostatState? previousState, DateTime now) {
+    if (previousState == null) {
+      return true;
+    }
+
+    if (previousState.silenceUntilOk) {
+      return false;
+    }
+
+    final snoozedUntil = previousState.snoozedUntil;
+    if (snoozedUntil != null && now.isBefore(snoozedUntil)) {
+      return false;
+    }
+
+    final lastAlarmAt = previousState.lastAlarmAt;
+    if (lastAlarmAt != null &&
+        previousState.status == ThermostatReadingStatus.outOfRange) {
+      final diff = now.difference(lastAlarmAt);
+      if (diff < _alarmRateLimit) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  String _formatOutOfRangeMessage(Thermostat thermostat, double valueC) {
+    return 'Out of range: ${valueC.toStringAsFixed(1)}°C '
+        '(${thermostat.minC.toStringAsFixed(1)}°C – ${thermostat.maxC.toStringAsFixed(1)}°C)';
+  }
 }
 
+abstract class ThermostatAlarmDispatcher {
+  Future<void> showAlarm({
+    required Thermostat thermostat,
+    required double valueC,
+    required DateTime triggeredAt,
+  });
+}
+
+class NotificationAlarmDispatcher implements ThermostatAlarmDispatcher {
+  NotificationAlarmDispatcher(this._notifications);
+
+  final FlutterLocalNotificationsPlugin _notifications;
+
+  @override
+  Future<void> showAlarm({
+    required Thermostat thermostat,
+    required double valueC,
+    required DateTime triggeredAt,
+  }) async {
+    final payload = jsonEncode({'thermostatId': thermostat.id});
+    await _notifications.show(
+      _alarmNotificationId(thermostat.id),
+      '${thermostat.name} out of range',
+      'Current ${valueC.toStringAsFixed(1)}°C • '
+          'Range ${thermostat.minC.toStringAsFixed(1)}°C – '
+          '${thermostat.maxC.toStringAsFixed(1)}°C',
+      NotificationDetails(
+        android: AndroidNotificationDetails(
+          _alarmChannel.id,
+          _alarmChannel.name,
+          channelDescription: _alarmChannel.description,
+          importance: Importance.max,
+          priority: Priority.high,
+          fullScreenIntent: true,
+          category: AndroidNotificationCategory.alarm,
+          ticker: 'Thermostat alarm',
+          autoCancel: false,
+          ongoing: true,
+          enableVibration: true,
+          playSound: true,
+          actions: const [
+            AndroidNotificationAction(_snooze5ActionId, 'Snooze 5 min'),
+            AndroidNotificationAction(_snooze10ActionId, 'Snooze 10 min'),
+            AndroidNotificationAction(_snooze30ActionId, 'Snooze 30 min'),
+            AndroidNotificationAction(_silenceActionId, 'Silence until OK'),
+          ],
+        ),
+      ),
+      payload: payload,
+    );
+  }
+}
+
+Future<void> cancelAlarmNotification(String thermostatId) {
+  final plugin = FlutterLocalNotificationsPlugin();
+  return plugin.cancel(_alarmNotificationId(thermostatId));
+}
+
+int _alarmNotificationId(String thermostatId) {
+  final hash = thermostatId.hashCode & 0x7fffffff;
+  return _alarmNotificationBaseId + (hash % 1000000);
+}
+
+typedef _NotificationResponseHandler =
+    Future<void> Function(NotificationResponse response);
+
 Future<void> _initializeNotifications(
-  FlutterLocalNotificationsPlugin plugin,
-) async {
+  FlutterLocalNotificationsPlugin plugin, {
+  _NotificationResponseHandler? onDidReceiveNotificationResponse,
+}) async {
   const initializationSettings = InitializationSettings(
     android: AndroidInitializationSettings('@mipmap/ic_launcher'),
   );
-  await plugin.initialize(initializationSettings);
+  await plugin.initialize(
+    initializationSettings,
+    onDidReceiveNotificationResponse: onDidReceiveNotificationResponse,
+  );
   final androidPlugin = plugin
       .resolvePlatformSpecificImplementation<
         AndroidFlutterLocalNotificationsPlugin
       >();
   await androidPlugin?.createNotificationChannel(_monitoringChannel);
+  await androidPlugin?.createNotificationChannel(_alarmChannel);
 }
 
 Future<void> _showMonitoringNotification(
@@ -168,4 +371,79 @@ Future<void> _showMonitoringNotification(
       ),
     ),
   );
+}
+
+Future<void> _handleNotificationResponse(NotificationResponse response) async {
+  final payload = response.payload;
+  if (payload == null || payload.isEmpty) {
+    return;
+  }
+
+  String? thermostatId;
+  try {
+    final data = jsonDecode(payload) as Map<String, dynamic>;
+    thermostatId = data['thermostatId'] as String?;
+  } catch (_) {
+    thermostatId = null;
+  }
+
+  if (thermostatId == null) {
+    return;
+  }
+
+  final actionId = response.actionId;
+  if (actionId == null || actionId.isEmpty) {
+    _navigateToAlarm(thermostatId);
+    await cancelAlarmNotification(thermostatId);
+    return;
+  }
+
+  final database = ThermostatDatabase();
+  final repository = ThermostatRepository(database);
+  try {
+    final now = DateTime.now().toUtc();
+    switch (actionId) {
+      case _snooze5ActionId:
+        await repository.updateSnoozedUntil(
+          thermostatId,
+          now.add(const Duration(minutes: 5)),
+        );
+        break;
+      case _snooze10ActionId:
+        await repository.updateSnoozedUntil(
+          thermostatId,
+          now.add(const Duration(minutes: 10)),
+        );
+        break;
+      case _snooze30ActionId:
+        await repository.updateSnoozedUntil(
+          thermostatId,
+          now.add(const Duration(minutes: 30)),
+        );
+        break;
+      case _silenceActionId:
+        await repository.updateSilenceUntilOk(thermostatId, true);
+        await repository.updateSnoozedUntil(thermostatId, null);
+        break;
+      default:
+        break;
+    }
+  } finally {
+    await database.close();
+  }
+
+  await cancelAlarmNotification(thermostatId);
+}
+
+void _navigateToAlarm(String thermostatId) {
+  void attemptNavigation() {
+    final context = rootNavigatorKey.currentContext;
+    if (context != null) {
+      GoRouter.of(context).push(AlarmRoute.pathFor(thermostatId));
+    } else {
+      WidgetsBinding.instance.addPostFrameCallback((_) => attemptNavigation());
+    }
+  }
+
+  attemptNavigation();
 }

--- a/app/lib/core/router/app_router.dart
+++ b/app/lib/core/router/app_router.dart
@@ -3,15 +3,31 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../features/settings/view/settings_page.dart';
+import '../../features/thermostats/view/alarm_fullscreen_page.dart';
 import '../../features/thermostats/view/thermostats_page.dart';
-
-final _rootNavigatorKey = GlobalKey<NavigatorState>();
+import 'router_keys.dart';
 
 final appRouterProvider = Provider<GoRouter>((ref) {
   return GoRouter(
-    navigatorKey: _rootNavigatorKey,
+    navigatorKey: rootNavigatorKey,
     initialLocation: ThermostatsRoute.path,
     routes: [
+      GoRoute(
+        path: AlarmRoute.path,
+        name: AlarmRoute.name,
+        parentNavigatorKey: rootNavigatorKey,
+        pageBuilder: (context, state) {
+          final thermostatId = state.pathParameters['id'];
+          if (thermostatId == null) {
+            return const NoTransitionPage(child: SizedBox.shrink());
+          }
+          return MaterialPage(
+            key: state.pageKey,
+            fullscreenDialog: true,
+            child: AlarmFullScreenPage(thermostatId: thermostatId),
+          );
+        },
+      ),
       StatefulShellRoute.indexedStack(
         builder: (context, state, navigationShell) {
           return AppScaffold(navigationShell: navigationShell);
@@ -82,4 +98,11 @@ class ThermostatsRoute {
 class SettingsRoute {
   static const name = 'settings';
   static const path = '/settings';
+}
+
+class AlarmRoute {
+  static const name = 'alarm';
+  static const path = '/alarm/:id';
+
+  static String pathFor(String thermostatId) => '/alarm/$thermostatId';
 }

--- a/app/lib/core/router/router_keys.dart
+++ b/app/lib/core/router/router_keys.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/widgets.dart';
+
+final GlobalKey<NavigatorState> rootNavigatorKey = GlobalKey<NavigatorState>(
+  debugLabel: 'rootNavigator',
+);

--- a/app/lib/features/thermostats/data/thermostat_database.dart
+++ b/app/lib/features/thermostats/data/thermostat_database.dart
@@ -45,6 +45,13 @@ class ThermostatStateEntries extends Table {
 
   TextColumn get statusMessage => text().nullable()();
 
+  DateTimeColumn get lastAlarmAt => dateTime().nullable()();
+
+  DateTimeColumn get snoozedUntil => dateTime().nullable()();
+
+  BoolColumn get silenceUntilOk =>
+      boolean().withDefault(const Constant(false))();
+
   DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
 
   DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
@@ -92,7 +99,7 @@ class ThermostatDatabase extends _$ThermostatDatabase {
   ThermostatDatabase.forTesting(super.executor);
 
   @override
-  int get schemaVersion => 3;
+  int get schemaVersion => 4;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -107,6 +114,20 @@ class ThermostatDatabase extends _$ThermostatDatabase {
         await m.addColumn(
           thermostatStateEntries,
           thermostatStateEntries.statusMessage,
+        );
+      }
+      if (from < 4) {
+        await m.addColumn(
+          thermostatStateEntries,
+          thermostatStateEntries.lastAlarmAt,
+        );
+        await m.addColumn(
+          thermostatStateEntries,
+          thermostatStateEntries.snoozedUntil,
+        );
+        await m.addColumn(
+          thermostatStateEntries,
+          thermostatStateEntries.silenceUntilOk,
         );
       }
     },
@@ -168,6 +189,24 @@ class ThermostatDatabase extends _$ThermostatDatabase {
     return (select(
       thermostatStateEntries,
     )..where((tbl) => tbl.thermostatId.equals(id))).getSingleOrNull();
+  }
+
+  Stream<ThermostatWithStateRow?> watchThermostatWithState(String id) {
+    final query = select(thermostatEntries).join([
+      leftOuterJoin(
+        thermostatStateEntries,
+        thermostatStateEntries.thermostatId.equalsExp(thermostatEntries.id),
+      ),
+    ])..where(thermostatEntries.id.equals(id));
+
+    return query.watchSingleOrNull().map(
+      (row) => row == null
+          ? null
+          : (
+              thermostat: row.readTable(thermostatEntries),
+              state: row.readTableOrNull(thermostatStateEntries),
+            ),
+    );
   }
 
   Future<void> upsertThermostat(ThermostatEntriesCompanion data) async {

--- a/app/lib/features/thermostats/data/thermostat_database.g.dart
+++ b/app/lib/features/thermostats/data/thermostat_database.g.dart
@@ -1120,6 +1120,43 @@ class $ThermostatStateEntriesTable extends ThermostatStateEntries
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _lastAlarmAtMeta = const VerificationMeta(
+    'lastAlarmAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> lastAlarmAt = GeneratedColumn<DateTime>(
+    'last_alarm_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _snoozedUntilMeta = const VerificationMeta(
+    'snoozedUntil',
+  );
+  @override
+  late final GeneratedColumn<DateTime> snoozedUntil = GeneratedColumn<DateTime>(
+    'snoozed_until',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _silenceUntilOkMeta = const VerificationMeta(
+    'silenceUntilOk',
+  );
+  @override
+  late final GeneratedColumn<bool> silenceUntilOk = GeneratedColumn<bool>(
+    'silence_until_ok',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("silence_until_ok" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
   static const VerificationMeta _createdAtMeta = const VerificationMeta(
     'createdAt',
   );
@@ -1152,6 +1189,9 @@ class $ThermostatStateEntriesTable extends ThermostatStateEntries
     lastFetchedAt,
     etag,
     statusMessage,
+    lastAlarmAt,
+    snoozedUntil,
+    silenceUntilOk,
     createdAt,
     updatedAt,
   ];
@@ -1217,6 +1257,33 @@ class $ThermostatStateEntriesTable extends ThermostatStateEntries
         ),
       );
     }
+    if (data.containsKey('last_alarm_at')) {
+      context.handle(
+        _lastAlarmAtMeta,
+        lastAlarmAt.isAcceptableOrUnknown(
+          data['last_alarm_at']!,
+          _lastAlarmAtMeta,
+        ),
+      );
+    }
+    if (data.containsKey('snoozed_until')) {
+      context.handle(
+        _snoozedUntilMeta,
+        snoozedUntil.isAcceptableOrUnknown(
+          data['snoozed_until']!,
+          _snoozedUntilMeta,
+        ),
+      );
+    }
+    if (data.containsKey('silence_until_ok')) {
+      context.handle(
+        _silenceUntilOkMeta,
+        silenceUntilOk.isAcceptableOrUnknown(
+          data['silence_until_ok']!,
+          _silenceUntilOkMeta,
+        ),
+      );
+    }
     if (data.containsKey('created_at')) {
       context.handle(
         _createdAtMeta,
@@ -1262,6 +1329,18 @@ class $ThermostatStateEntriesTable extends ThermostatStateEntries
         DriftSqlType.string,
         data['${effectivePrefix}status_message'],
       ),
+      lastAlarmAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}last_alarm_at'],
+      ),
+      snoozedUntil: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}snoozed_until'],
+      ),
+      silenceUntilOk: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}silence_until_ok'],
+      )!,
       createdAt: attachedDatabase.typeMapping.read(
         DriftSqlType.dateTime,
         data['${effectivePrefix}created_at'],
@@ -1287,6 +1366,9 @@ class ThermostatStateEntry extends DataClass
   final DateTime? lastFetchedAt;
   final String? etag;
   final String? statusMessage;
+  final DateTime? lastAlarmAt;
+  final DateTime? snoozedUntil;
+  final bool silenceUntilOk;
   final DateTime createdAt;
   final DateTime updatedAt;
   const ThermostatStateEntry({
@@ -1296,6 +1378,9 @@ class ThermostatStateEntry extends DataClass
     this.lastFetchedAt,
     this.etag,
     this.statusMessage,
+    this.lastAlarmAt,
+    this.snoozedUntil,
+    required this.silenceUntilOk,
     required this.createdAt,
     required this.updatedAt,
   });
@@ -1318,6 +1403,13 @@ class ThermostatStateEntry extends DataClass
     if (!nullToAbsent || statusMessage != null) {
       map['status_message'] = Variable<String>(statusMessage);
     }
+    if (!nullToAbsent || lastAlarmAt != null) {
+      map['last_alarm_at'] = Variable<DateTime>(lastAlarmAt);
+    }
+    if (!nullToAbsent || snoozedUntil != null) {
+      map['snoozed_until'] = Variable<DateTime>(snoozedUntil);
+    }
+    map['silence_until_ok'] = Variable<bool>(silenceUntilOk);
     map['created_at'] = Variable<DateTime>(createdAt);
     map['updated_at'] = Variable<DateTime>(updatedAt);
     return map;
@@ -1339,6 +1431,13 @@ class ThermostatStateEntry extends DataClass
       statusMessage: statusMessage == null && nullToAbsent
           ? const Value.absent()
           : Value(statusMessage),
+      lastAlarmAt: lastAlarmAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lastAlarmAt),
+      snoozedUntil: snoozedUntil == null && nullToAbsent
+          ? const Value.absent()
+          : Value(snoozedUntil),
+      silenceUntilOk: Value(silenceUntilOk),
       createdAt: Value(createdAt),
       updatedAt: Value(updatedAt),
     );
@@ -1356,6 +1455,9 @@ class ThermostatStateEntry extends DataClass
       lastFetchedAt: serializer.fromJson<DateTime?>(json['lastFetchedAt']),
       etag: serializer.fromJson<String?>(json['etag']),
       statusMessage: serializer.fromJson<String?>(json['statusMessage']),
+      lastAlarmAt: serializer.fromJson<DateTime?>(json['lastAlarmAt']),
+      snoozedUntil: serializer.fromJson<DateTime?>(json['snoozedUntil']),
+      silenceUntilOk: serializer.fromJson<bool>(json['silenceUntilOk']),
       createdAt: serializer.fromJson<DateTime>(json['createdAt']),
       updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
     );
@@ -1370,6 +1472,9 @@ class ThermostatStateEntry extends DataClass
       'lastFetchedAt': serializer.toJson<DateTime?>(lastFetchedAt),
       'etag': serializer.toJson<String?>(etag),
       'statusMessage': serializer.toJson<String?>(statusMessage),
+      'lastAlarmAt': serializer.toJson<DateTime?>(lastAlarmAt),
+      'snoozedUntil': serializer.toJson<DateTime?>(snoozedUntil),
+      'silenceUntilOk': serializer.toJson<bool>(silenceUntilOk),
       'createdAt': serializer.toJson<DateTime>(createdAt),
       'updatedAt': serializer.toJson<DateTime>(updatedAt),
     };
@@ -1382,6 +1487,9 @@ class ThermostatStateEntry extends DataClass
     Value<DateTime?> lastFetchedAt = const Value.absent(),
     Value<String?> etag = const Value.absent(),
     Value<String?> statusMessage = const Value.absent(),
+    Value<DateTime?> lastAlarmAt = const Value.absent(),
+    Value<DateTime?> snoozedUntil = const Value.absent(),
+    bool? silenceUntilOk,
     DateTime? createdAt,
     DateTime? updatedAt,
   }) => ThermostatStateEntry(
@@ -1395,6 +1503,9 @@ class ThermostatStateEntry extends DataClass
     statusMessage: statusMessage.present
         ? statusMessage.value
         : this.statusMessage,
+    lastAlarmAt: lastAlarmAt.present ? lastAlarmAt.value : this.lastAlarmAt,
+    snoozedUntil: snoozedUntil.present ? snoozedUntil.value : this.snoozedUntil,
+    silenceUntilOk: silenceUntilOk ?? this.silenceUntilOk,
     createdAt: createdAt ?? this.createdAt,
     updatedAt: updatedAt ?? this.updatedAt,
   );
@@ -1416,6 +1527,15 @@ class ThermostatStateEntry extends DataClass
       statusMessage: data.statusMessage.present
           ? data.statusMessage.value
           : this.statusMessage,
+      lastAlarmAt: data.lastAlarmAt.present
+          ? data.lastAlarmAt.value
+          : this.lastAlarmAt,
+      snoozedUntil: data.snoozedUntil.present
+          ? data.snoozedUntil.value
+          : this.snoozedUntil,
+      silenceUntilOk: data.silenceUntilOk.present
+          ? data.silenceUntilOk.value
+          : this.silenceUntilOk,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
     );
@@ -1430,6 +1550,9 @@ class ThermostatStateEntry extends DataClass
           ..write('lastFetchedAt: $lastFetchedAt, ')
           ..write('etag: $etag, ')
           ..write('statusMessage: $statusMessage, ')
+          ..write('lastAlarmAt: $lastAlarmAt, ')
+          ..write('snoozedUntil: $snoozedUntil, ')
+          ..write('silenceUntilOk: $silenceUntilOk, ')
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt')
           ..write(')'))
@@ -1444,6 +1567,9 @@ class ThermostatStateEntry extends DataClass
     lastFetchedAt,
     etag,
     statusMessage,
+    lastAlarmAt,
+    snoozedUntil,
+    silenceUntilOk,
     createdAt,
     updatedAt,
   );
@@ -1457,6 +1583,9 @@ class ThermostatStateEntry extends DataClass
           other.lastFetchedAt == this.lastFetchedAt &&
           other.etag == this.etag &&
           other.statusMessage == this.statusMessage &&
+          other.lastAlarmAt == this.lastAlarmAt &&
+          other.snoozedUntil == this.snoozedUntil &&
+          other.silenceUntilOk == this.silenceUntilOk &&
           other.createdAt == this.createdAt &&
           other.updatedAt == this.updatedAt);
 }
@@ -1469,6 +1598,9 @@ class ThermostatStateEntriesCompanion
   final Value<DateTime?> lastFetchedAt;
   final Value<String?> etag;
   final Value<String?> statusMessage;
+  final Value<DateTime?> lastAlarmAt;
+  final Value<DateTime?> snoozedUntil;
+  final Value<bool> silenceUntilOk;
   final Value<DateTime> createdAt;
   final Value<DateTime> updatedAt;
   final Value<int> rowid;
@@ -1479,6 +1611,9 @@ class ThermostatStateEntriesCompanion
     this.lastFetchedAt = const Value.absent(),
     this.etag = const Value.absent(),
     this.statusMessage = const Value.absent(),
+    this.lastAlarmAt = const Value.absent(),
+    this.snoozedUntil = const Value.absent(),
+    this.silenceUntilOk = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -1490,6 +1625,9 @@ class ThermostatStateEntriesCompanion
     this.lastFetchedAt = const Value.absent(),
     this.etag = const Value.absent(),
     this.statusMessage = const Value.absent(),
+    this.lastAlarmAt = const Value.absent(),
+    this.snoozedUntil = const Value.absent(),
+    this.silenceUntilOk = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -1501,6 +1639,9 @@ class ThermostatStateEntriesCompanion
     Expression<DateTime>? lastFetchedAt,
     Expression<String>? etag,
     Expression<String>? statusMessage,
+    Expression<DateTime>? lastAlarmAt,
+    Expression<DateTime>? snoozedUntil,
+    Expression<bool>? silenceUntilOk,
     Expression<DateTime>? createdAt,
     Expression<DateTime>? updatedAt,
     Expression<int>? rowid,
@@ -1512,6 +1653,9 @@ class ThermostatStateEntriesCompanion
       if (lastFetchedAt != null) 'last_fetched_at': lastFetchedAt,
       if (etag != null) 'etag': etag,
       if (statusMessage != null) 'status_message': statusMessage,
+      if (lastAlarmAt != null) 'last_alarm_at': lastAlarmAt,
+      if (snoozedUntil != null) 'snoozed_until': snoozedUntil,
+      if (silenceUntilOk != null) 'silence_until_ok': silenceUntilOk,
       if (createdAt != null) 'created_at': createdAt,
       if (updatedAt != null) 'updated_at': updatedAt,
       if (rowid != null) 'rowid': rowid,
@@ -1525,6 +1669,9 @@ class ThermostatStateEntriesCompanion
     Value<DateTime?>? lastFetchedAt,
     Value<String?>? etag,
     Value<String?>? statusMessage,
+    Value<DateTime?>? lastAlarmAt,
+    Value<DateTime?>? snoozedUntil,
+    Value<bool>? silenceUntilOk,
     Value<DateTime>? createdAt,
     Value<DateTime>? updatedAt,
     Value<int>? rowid,
@@ -1536,6 +1683,9 @@ class ThermostatStateEntriesCompanion
       lastFetchedAt: lastFetchedAt ?? this.lastFetchedAt,
       etag: etag ?? this.etag,
       statusMessage: statusMessage ?? this.statusMessage,
+      lastAlarmAt: lastAlarmAt ?? this.lastAlarmAt,
+      snoozedUntil: snoozedUntil ?? this.snoozedUntil,
+      silenceUntilOk: silenceUntilOk ?? this.silenceUntilOk,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
       rowid: rowid ?? this.rowid,
@@ -1563,6 +1713,15 @@ class ThermostatStateEntriesCompanion
     if (statusMessage.present) {
       map['status_message'] = Variable<String>(statusMessage.value);
     }
+    if (lastAlarmAt.present) {
+      map['last_alarm_at'] = Variable<DateTime>(lastAlarmAt.value);
+    }
+    if (snoozedUntil.present) {
+      map['snoozed_until'] = Variable<DateTime>(snoozedUntil.value);
+    }
+    if (silenceUntilOk.present) {
+      map['silence_until_ok'] = Variable<bool>(silenceUntilOk.value);
+    }
     if (createdAt.present) {
       map['created_at'] = Variable<DateTime>(createdAt.value);
     }
@@ -1584,6 +1743,9 @@ class ThermostatStateEntriesCompanion
           ..write('lastFetchedAt: $lastFetchedAt, ')
           ..write('etag: $etag, ')
           ..write('statusMessage: $statusMessage, ')
+          ..write('lastAlarmAt: $lastAlarmAt, ')
+          ..write('snoozedUntil: $snoozedUntil, ')
+          ..write('silenceUntilOk: $silenceUntilOk, ')
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt, ')
           ..write('rowid: $rowid')
@@ -2165,6 +2327,10 @@ typedef $$ThermostatStateEntriesTableCreateCompanionBuilder =
       Value<String?> lastStatus,
       Value<DateTime?> lastFetchedAt,
       Value<String?> etag,
+      Value<String?> statusMessage,
+      Value<DateTime?> lastAlarmAt,
+      Value<DateTime?> snoozedUntil,
+      Value<bool> silenceUntilOk,
       Value<DateTime> createdAt,
       Value<DateTime> updatedAt,
       Value<int> rowid,
@@ -2176,6 +2342,10 @@ typedef $$ThermostatStateEntriesTableUpdateCompanionBuilder =
       Value<String?> lastStatus,
       Value<DateTime?> lastFetchedAt,
       Value<String?> etag,
+      Value<String?> statusMessage,
+      Value<DateTime?> lastAlarmAt,
+      Value<DateTime?> snoozedUntil,
+      Value<bool> silenceUntilOk,
       Value<DateTime> createdAt,
       Value<DateTime> updatedAt,
       Value<int> rowid,
@@ -2212,6 +2382,26 @@ class $$ThermostatStateEntriesTableFilterComposer
 
   ColumnFilters<String> get etag => $composableBuilder(
     column: $table.etag,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get statusMessage => $composableBuilder(
+    column: $table.statusMessage,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get lastAlarmAt => $composableBuilder(
+    column: $table.lastAlarmAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get snoozedUntil => $composableBuilder(
+    column: $table.snoozedUntil,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get silenceUntilOk => $composableBuilder(
+    column: $table.silenceUntilOk,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -2260,6 +2450,26 @@ class $$ThermostatStateEntriesTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get statusMessage => $composableBuilder(
+    column: $table.statusMessage,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get lastAlarmAt => $composableBuilder(
+    column: $table.lastAlarmAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get snoozedUntil => $composableBuilder(
+    column: $table.snoozedUntil,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get silenceUntilOk => $composableBuilder(
+    column: $table.silenceUntilOk,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<DateTime> get createdAt => $composableBuilder(
     column: $table.createdAt,
     builder: (column) => ColumnOrderings(column),
@@ -2302,6 +2512,26 @@ class $$ThermostatStateEntriesTableAnnotationComposer
 
   GeneratedColumn<String> get etag =>
       $composableBuilder(column: $table.etag, builder: (column) => column);
+
+  GeneratedColumn<String> get statusMessage => $composableBuilder(
+    column: $table.statusMessage,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get lastAlarmAt => $composableBuilder(
+    column: $table.lastAlarmAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get snoozedUntil => $composableBuilder(
+    column: $table.snoozedUntil,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<bool> get silenceUntilOk => $composableBuilder(
+    column: $table.silenceUntilOk,
+    builder: (column) => column,
+  );
 
   GeneratedColumn<DateTime> get createdAt =>
       $composableBuilder(column: $table.createdAt, builder: (column) => column);
@@ -2361,6 +2591,10 @@ class $$ThermostatStateEntriesTableTableManager
                 Value<String?> lastStatus = const Value.absent(),
                 Value<DateTime?> lastFetchedAt = const Value.absent(),
                 Value<String?> etag = const Value.absent(),
+                Value<String?> statusMessage = const Value.absent(),
+                Value<DateTime?> lastAlarmAt = const Value.absent(),
+                Value<DateTime?> snoozedUntil = const Value.absent(),
+                Value<bool> silenceUntilOk = const Value.absent(),
                 Value<DateTime> createdAt = const Value.absent(),
                 Value<DateTime> updatedAt = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
@@ -2370,6 +2604,10 @@ class $$ThermostatStateEntriesTableTableManager
                 lastStatus: lastStatus,
                 lastFetchedAt: lastFetchedAt,
                 etag: etag,
+                statusMessage: statusMessage,
+                lastAlarmAt: lastAlarmAt,
+                snoozedUntil: snoozedUntil,
+                silenceUntilOk: silenceUntilOk,
                 createdAt: createdAt,
                 updatedAt: updatedAt,
                 rowid: rowid,
@@ -2381,6 +2619,10 @@ class $$ThermostatStateEntriesTableTableManager
                 Value<String?> lastStatus = const Value.absent(),
                 Value<DateTime?> lastFetchedAt = const Value.absent(),
                 Value<String?> etag = const Value.absent(),
+                Value<String?> statusMessage = const Value.absent(),
+                Value<DateTime?> lastAlarmAt = const Value.absent(),
+                Value<DateTime?> snoozedUntil = const Value.absent(),
+                Value<bool> silenceUntilOk = const Value.absent(),
                 Value<DateTime> createdAt = const Value.absent(),
                 Value<DateTime> updatedAt = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
@@ -2390,6 +2632,10 @@ class $$ThermostatStateEntriesTableTableManager
                 lastStatus: lastStatus,
                 lastFetchedAt: lastFetchedAt,
                 etag: etag,
+                statusMessage: statusMessage,
+                lastAlarmAt: lastAlarmAt,
+                snoozedUntil: snoozedUntil,
+                silenceUntilOk: silenceUntilOk,
                 createdAt: createdAt,
                 updatedAt: updatedAt,
                 rowid: rowid,

--- a/app/lib/features/thermostats/data/thermostat_repository.dart
+++ b/app/lib/features/thermostats/data/thermostat_repository.dart
@@ -41,6 +41,18 @@ class ThermostatRepository {
         .toList();
   }
 
+  Stream<ThermostatSummary?> watchThermostat(String id) {
+    return _database.watchThermostatWithState(id).map((row) {
+      if (row == null) {
+        return null;
+      }
+      return ThermostatSummary(
+        thermostat: Thermostat.fromEntry(row.thermostat),
+        state: row.state != null ? ThermostatState.fromEntry(row.state!) : null,
+      );
+    });
+  }
+
   Future<Thermostat> create(ThermostatDraft draft) async {
     final validation = ThermostatValidator.validate(draft);
     if (!validation.isValid) {
@@ -114,6 +126,12 @@ class ThermostatRepository {
     DateTime? fetchedAt,
     String? etag,
     String? message,
+    DateTime? lastAlarmAt,
+    bool setLastAlarmAt = false,
+    DateTime? snoozedUntil,
+    bool setSnoozedUntil = false,
+    bool? silenceUntilOk,
+    bool setSilenceUntilOk = false,
   }) async {
     final now = DateTime.now().toUtc();
     await _database.upsertThermostatState(
@@ -130,7 +148,44 @@ class ThermostatRepository {
         statusMessage: message != null
             ? drift.Value(message)
             : const drift.Value.absent(),
+        lastAlarmAt: setLastAlarmAt
+            ? (lastAlarmAt != null
+                  ? drift.Value(lastAlarmAt)
+                  : const drift.Value(null))
+            : const drift.Value.absent(),
+        snoozedUntil: setSnoozedUntil
+            ? (snoozedUntil != null
+                  ? drift.Value(snoozedUntil)
+                  : const drift.Value(null))
+            : const drift.Value.absent(),
+        silenceUntilOk: setSilenceUntilOk && silenceUntilOk != null
+            ? drift.Value(silenceUntilOk)
+            : const drift.Value.absent(),
         createdAt: const drift.Value.absent(),
+        updatedAt: drift.Value(now),
+      ),
+    );
+  }
+
+  Future<void> updateSnoozedUntil(String thermostatId, DateTime? until) async {
+    final now = DateTime.now().toUtc();
+    await _database.upsertThermostatState(
+      ThermostatStateEntriesCompanion(
+        thermostatId: drift.Value(thermostatId),
+        snoozedUntil: until != null
+            ? drift.Value(until)
+            : const drift.Value(null),
+        updatedAt: drift.Value(now),
+      ),
+    );
+  }
+
+  Future<void> updateSilenceUntilOk(String thermostatId, bool value) async {
+    final now = DateTime.now().toUtc();
+    await _database.upsertThermostatState(
+      ThermostatStateEntriesCompanion(
+        thermostatId: drift.Value(thermostatId),
+        silenceUntilOk: drift.Value(value),
         updatedAt: drift.Value(now),
       ),
     );

--- a/app/lib/features/thermostats/models/thermostat_state.dart
+++ b/app/lib/features/thermostats/models/thermostat_state.dart
@@ -12,6 +12,9 @@ class ThermostatState {
     this.lastFetchedAt,
     this.etag,
     this.statusMessage,
+    this.lastAlarmAt,
+    this.snoozedUntil,
+    this.silenceUntilOk = false,
     required this.createdAt,
     required this.updatedAt,
   });
@@ -22,6 +25,9 @@ class ThermostatState {
   final DateTime? lastFetchedAt;
   final String? etag;
   final String? statusMessage;
+  final DateTime? lastAlarmAt;
+  final DateTime? snoozedUntil;
+  final bool silenceUntilOk;
   final DateTime createdAt;
   final DateTime updatedAt;
 
@@ -33,6 +39,9 @@ class ThermostatState {
       lastFetchedAt: entry.lastFetchedAt?.toUtc(),
       etag: entry.etag,
       statusMessage: entry.statusMessage,
+      lastAlarmAt: entry.lastAlarmAt?.toUtc(),
+      snoozedUntil: entry.snoozedUntil?.toUtc(),
+      silenceUntilOk: entry.silenceUntilOk,
       createdAt: entry.createdAt.toUtc(),
       updatedAt: entry.updatedAt.toUtc(),
     );
@@ -44,6 +53,9 @@ class ThermostatState {
     DateTime? lastFetchedAt,
     String? etag,
     String? statusMessage,
+    DateTime? lastAlarmAt,
+    DateTime? snoozedUntil,
+    bool? silenceUntilOk,
     DateTime? updatedAt,
   }) {
     return ThermostatState(
@@ -53,6 +65,9 @@ class ThermostatState {
       lastFetchedAt: lastFetchedAt ?? this.lastFetchedAt,
       etag: etag ?? this.etag,
       statusMessage: statusMessage ?? this.statusMessage,
+      lastAlarmAt: lastAlarmAt ?? this.lastAlarmAt,
+      snoozedUntil: snoozedUntil ?? this.snoozedUntil,
+      silenceUntilOk: silenceUntilOk ?? this.silenceUntilOk,
       createdAt: createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
     );
@@ -69,6 +84,7 @@ class ThermostatSummary {
 
 enum ThermostatReadingStatus {
   ok,
+  outOfRange,
   networkError,
   httpError,
   parseError,

--- a/app/lib/features/thermostats/providers/thermostat_providers.dart
+++ b/app/lib/features/thermostats/providers/thermostat_providers.dart
@@ -31,3 +31,9 @@ final thermostatsProvider = StreamProvider<List<ThermostatSummary>>((ref) {
   final repository = ref.watch(thermostatRepositoryProvider);
   return repository.watchThermostats();
 });
+
+final thermostatSummaryProvider =
+    StreamProvider.family<ThermostatSummary?, String>((ref, thermostatId) {
+      final repository = ref.watch(thermostatRepositoryProvider);
+      return repository.watchThermostat(thermostatId);
+    });

--- a/app/lib/features/thermostats/view/alarm_fullscreen_page.dart
+++ b/app/lib/features/thermostats/view/alarm_fullscreen_page.dart
@@ -95,7 +95,7 @@ class _AlarmContent extends ConsumerWidget {
               Text(
                 thermostatName,
                 style: textTheme.headlineMedium?.copyWith(
-                  color: colorScheme.onBackground,
+                  color: colorScheme.onSurface,
                   fontWeight: FontWeight.bold,
                 ),
                 textAlign: TextAlign.center,
@@ -104,7 +104,7 @@ class _AlarmContent extends ConsumerWidget {
               Text(
                 valueText,
                 style: textTheme.displayMedium?.copyWith(
-                  color: colorScheme.onBackground,
+                  color: colorScheme.onSurface,
                   fontWeight: FontWeight.bold,
                 ),
               ),
@@ -112,7 +112,7 @@ class _AlarmContent extends ConsumerWidget {
               Text(
                 'Target range ${minC.toStringAsFixed(1)}°C – ${maxC.toStringAsFixed(1)}°C',
                 style: textTheme.titleMedium?.copyWith(
-                  color: colorScheme.onBackground.withOpacity(0.8),
+                  color: colorScheme.onSurface.withValues(alpha: 0.8),
                 ),
                 textAlign: TextAlign.center,
               ),
@@ -170,7 +170,7 @@ class _AlarmContent extends ConsumerWidget {
               child: Text(
                 line,
                 style: textTheme.titleMedium?.copyWith(
-                  color: colorScheme.onBackground.withOpacity(0.9),
+                  color: colorScheme.onSurface.withValues(alpha: 0.9),
                 ),
                 textAlign: TextAlign.center,
               ),

--- a/app/lib/features/thermostats/view/alarm_fullscreen_page.dart
+++ b/app/lib/features/thermostats/view/alarm_fullscreen_page.dart
@@ -1,0 +1,299 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/background/thermostat_monitor.dart';
+import '../models/thermostat_state.dart';
+import '../providers/thermostat_providers.dart';
+
+class AlarmFullScreenPage extends ConsumerWidget {
+  const AlarmFullScreenPage({required this.thermostatId, super.key});
+
+  final String thermostatId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final summaryAsync = ref.watch(thermostatSummaryProvider(thermostatId));
+
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: SafeArea(
+        child: summaryAsync.when(
+          data: (summary) {
+            if (summary == null) {
+              return const _MissingThermostat();
+            }
+            final thermostat = summary.thermostat;
+            final state = summary.state;
+            return _AlarmContent(
+              thermostatId: thermostat.id,
+              thermostatName: thermostat.name,
+              currentValue: state?.lastValueC,
+              minC: thermostat.minC,
+              maxC: thermostat.maxC,
+              status: state?.status,
+              statusMessage: state?.statusMessage,
+              snoozedUntil: state?.snoozedUntil,
+              silenceUntilOk: state?.silenceUntilOk ?? false,
+            );
+          },
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (error, stackTrace) => _AlarmError(error: error),
+        ),
+      ),
+    );
+  }
+}
+
+class _AlarmContent extends ConsumerWidget {
+  const _AlarmContent({
+    required this.thermostatId,
+    required this.thermostatName,
+    required this.currentValue,
+    required this.minC,
+    required this.maxC,
+    required this.status,
+    required this.statusMessage,
+    required this.snoozedUntil,
+    required this.silenceUntilOk,
+  });
+
+  final String thermostatId;
+  final String thermostatName;
+  final double? currentValue;
+  final double minC;
+  final double maxC;
+  final ThermostatReadingStatus? status;
+  final String? statusMessage;
+  final DateTime? snoozedUntil;
+  final bool silenceUntilOk;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final valueText = currentValue != null
+        ? '${currentValue!.toStringAsFixed(1)}°C'
+        : 'Unavailable';
+
+    final statusDetails = _buildStatusDetails(context, textTheme, colorScheme);
+
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              const SizedBox(height: 24),
+              Icon(
+                Icons.warning_amber_rounded,
+                size: 96,
+                color: colorScheme.error,
+              ),
+              const SizedBox(height: 24),
+              Text(
+                thermostatName,
+                style: textTheme.headlineMedium?.copyWith(
+                  color: colorScheme.onBackground,
+                  fontWeight: FontWeight.bold,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                valueText,
+                style: textTheme.displayMedium?.copyWith(
+                  color: colorScheme.onBackground,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Target range ${minC.toStringAsFixed(1)}°C – ${maxC.toStringAsFixed(1)}°C',
+                style: textTheme.titleMedium?.copyWith(
+                  color: colorScheme.onBackground.withOpacity(0.8),
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 24),
+              statusDetails,
+            ],
+          ),
+          _AlarmActions(
+            thermostatId: thermostatId,
+            silenceUntilOk: silenceUntilOk,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatusDetails(
+    BuildContext context,
+    TextTheme textTheme,
+    ColorScheme colorScheme,
+  ) {
+    final buffer = <String>[];
+    if (statusMessage != null && statusMessage!.isNotEmpty) {
+      buffer.add(statusMessage!);
+    }
+    if (snoozedUntil != null) {
+      final formattedTime = MaterialLocalizations.of(
+        context,
+      ).formatTimeOfDay(TimeOfDay.fromDateTime(snoozedUntil!.toLocal()));
+      buffer.add('Snoozed until $formattedTime');
+    }
+    if (silenceUntilOk) {
+      buffer.add('Silenced until reading returns to range.');
+    }
+    if (buffer.isEmpty) {
+      switch (status) {
+        case ThermostatReadingStatus.outOfRange:
+          buffer.add('Temperature is outside the configured range.');
+          break;
+        case ThermostatReadingStatus.networkError:
+        case ThermostatReadingStatus.httpError:
+        case ThermostatReadingStatus.parseError:
+        case ThermostatReadingStatus.unknown:
+        case ThermostatReadingStatus.ok:
+        case null:
+          break;
+      }
+    }
+
+    return Column(
+      children: buffer
+          .map(
+            (line) => Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4),
+              child: Text(
+                line,
+                style: textTheme.titleMedium?.copyWith(
+                  color: colorScheme.onBackground.withOpacity(0.9),
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          )
+          .toList(),
+    );
+  }
+}
+
+class _AlarmActions extends ConsumerWidget {
+  const _AlarmActions({
+    required this.thermostatId,
+    required this.silenceUntilOk,
+  });
+
+  final String thermostatId;
+  final bool silenceUntilOk;
+
+  Future<void> _setSnooze(
+    BuildContext context,
+    WidgetRef ref,
+    Duration duration,
+  ) async {
+    final repository = ref.read(thermostatRepositoryProvider);
+    final until = DateTime.now().toUtc().add(duration);
+    await repository.updateSnoozedUntil(thermostatId, until);
+    await cancelAlarmNotification(thermostatId);
+    if (context.mounted) {
+      Navigator.of(context).pop();
+    }
+  }
+
+  Future<void> _setSilence(BuildContext context, WidgetRef ref) async {
+    final repository = ref.read(thermostatRepositoryProvider);
+    await repository.updateSilenceUntilOk(thermostatId, true);
+    await repository.updateSnoozedUntil(thermostatId, null);
+    await cancelAlarmNotification(thermostatId);
+    if (context.mounted) {
+      Navigator.of(context).pop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final textTheme = Theme.of(context).textTheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Wrap(
+          alignment: WrapAlignment.center,
+          spacing: 12,
+          runSpacing: 12,
+          children: [
+            FilledButton(
+              onPressed: () =>
+                  _setSnooze(context, ref, const Duration(minutes: 5)),
+              child: const Text('Snooze 5 min'),
+            ),
+            FilledButton.tonal(
+              onPressed: () =>
+                  _setSnooze(context, ref, const Duration(minutes: 10)),
+              child: const Text('Snooze 10 min'),
+            ),
+            FilledButton.tonal(
+              onPressed: () =>
+                  _setSnooze(context, ref, const Duration(minutes: 30)),
+              child: const Text('Snooze 30 min'),
+            ),
+            OutlinedButton(
+              onPressed: silenceUntilOk
+                  ? null
+                  : () => _setSilence(context, ref),
+              child: const Text('Silence until OK'),
+            ),
+          ],
+        ),
+        const SizedBox(height: 24),
+        TextButton(
+          onPressed: () async {
+            await cancelAlarmNotification(thermostatId);
+            if (!context.mounted) {
+              return;
+            }
+            Navigator.of(context).pop();
+          },
+          child: Text('Dismiss', style: textTheme.titleMedium),
+        ),
+      ],
+    );
+  }
+}
+
+class _MissingThermostat extends StatelessWidget {
+  const _MissingThermostat();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text(
+        'Thermostat not found.',
+        style: TextStyle(color: Colors.white),
+      ),
+    );
+  }
+}
+
+class _AlarmError extends StatelessWidget {
+  const _AlarmError({required this.error});
+
+  final Object error;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text(
+          'Failed to load alarm details: $error',
+          textAlign: TextAlign.center,
+          style: const TextStyle(color: Colors.white),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/thermostats/widgets/thermostat_card.dart
+++ b/app/lib/features/thermostats/widgets/thermostat_card.dart
@@ -137,6 +137,13 @@ class _LastSeenStatus extends StatelessWidget {
         statusText = '$base • Checked $relative';
         isError = true;
         break;
+      case ThermostatReadingStatus.outOfRange:
+        final base = message ?? 'Temperature outside configured range';
+        statusText = value != null
+            ? '$base (${value.toStringAsFixed(1)}°C) • Updated $relative'
+            : '$base • Updated $relative';
+        isError = true;
+        break;
       case ThermostatReadingStatus.httpError:
         final base = message ?? 'Last attempt failed: server error';
         statusText = '$base • Checked $relative';

--- a/app/test/unit/thermostat_monitor_runner_test.dart
+++ b/app/test/unit/thermostat_monitor_runner_test.dart
@@ -11,7 +11,7 @@ import 'package:farmctl/features/thermostats/models/thermostat_state.dart';
 class _FakeNetwork implements ThermostatNetworkDataSource {
   _FakeNetwork(this._result);
 
-  final ThermostatFetchSuccess? _result;
+  ThermostatFetchSuccess? _result;
   ThermostatFetchException? _exception;
 
   @override
@@ -27,10 +27,24 @@ class _FakeNetwork implements ThermostatNetworkDataSource {
   }
 }
 
+class _RecordingAlarmDispatcher implements ThermostatAlarmDispatcher {
+  final List<String> triggered = [];
+
+  @override
+  Future<void> showAlarm({
+    required Thermostat thermostat,
+    required double valueC,
+    required DateTime triggeredAt,
+  }) async {
+    triggered.add('${thermostat.id}::$valueC');
+  }
+}
+
 void main() {
   late ThermostatDatabase database;
   late ThermostatRepository repository;
   late _FakeNetwork network;
+  late _RecordingAlarmDispatcher alarms;
 
   setUp(() {
     database = ThermostatDatabase.forTesting(NativeDatabase.memory());
@@ -42,6 +56,7 @@ void main() {
         etag: 'etag',
       ),
     );
+    alarms = _RecordingAlarmDispatcher();
   });
 
   tearDown(() async {
@@ -54,13 +69,14 @@ void main() {
         name: 'Barn',
         rawUrl: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
         minC: 0,
-        maxC: 20,
+        maxC: 30,
       ),
     );
 
     final runner = ThermostatMonitorRunner(
       repository: repository,
       network: network,
+      alarmDispatcher: alarms,
       clock: () => DateTime.utc(2025, 1, 1, 13),
     );
 
@@ -72,13 +88,47 @@ void main() {
     expect(state.lastValueC, 21.5);
     expect(state.statusMessage, 'Fetched 21.5°C');
     expect(state.etag, 'etag');
+    expect(alarms.triggered, isEmpty);
+  });
+
+  test('run marks thermostat out of range and triggers alarm', () async {
+    final thermostat = await repository.create(
+      ThermostatDraft(
+        name: 'Greenhouse',
+        rawUrl: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        minC: 0,
+        maxC: 20,
+      ),
+    );
+
+    network._result = ThermostatFetchSuccess(
+      valueC: 25.2,
+      fetchedAt: DateTime.utc(2025, 1, 1, 12, 15),
+      etag: 'etag-2',
+    );
+
+    final runner = ThermostatMonitorRunner(
+      repository: repository,
+      network: network,
+      alarmDispatcher: alarms,
+      clock: () => DateTime.utc(2025, 1, 1, 12, 16),
+    );
+
+    await runner.run();
+
+    final state = await repository.loadState(thermostat.id);
+    expect(state, isNotNull);
+    expect(state!.status, ThermostatReadingStatus.outOfRange);
+    expect(state.statusMessage, 'Out of range: 25.2°C (0.0°C – 20.0°C)');
+    expect(state.lastAlarmAt, DateTime.utc(2025, 1, 1, 12, 16));
+    expect(alarms.triggered, contains('${thermostat.id}::25.2'));
   });
 
   test('run records failure details', () async {
     final thermostat = await repository.create(
       ThermostatDraft(
-        name: 'Greenhouse',
-        rawUrl: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        name: 'Greenhouse East',
+        rawUrl: 'cccccccccccccccccccccccccccccccc',
         minC: 2,
         maxC: 12,
       ),
@@ -92,6 +142,7 @@ void main() {
     final runner = ThermostatMonitorRunner(
       repository: repository,
       network: network,
+      alarmDispatcher: alarms,
       clock: () => DateTime.utc(2025, 1, 1, 13),
     );
 
@@ -102,5 +153,53 @@ void main() {
     expect(state!.status, ThermostatReadingStatus.networkError);
     expect(state.statusMessage, 'network down');
     expect(state.lastFetchedAt, DateTime.utc(2025, 1, 1, 13));
+    expect(alarms.triggered, isEmpty);
+  });
+
+  test('run respects snooze window', () async {
+    final thermostat = await repository.create(
+      ThermostatDraft(
+        name: 'Propagation',
+        rawUrl: 'dddddddddddddddddddddddddddddddd',
+        minC: 10,
+        maxC: 20,
+      ),
+    );
+
+    final now = DateTime.utc(2025, 1, 1, 12);
+    await repository.saveState(
+      thermostatId: thermostat.id,
+      status: ThermostatReadingStatus.outOfRange,
+      valueC: 5,
+      fetchedAt: now.subtract(const Duration(minutes: 10)),
+      etag: 'etag',
+      message: 'Out of range',
+      lastAlarmAt: now.subtract(const Duration(minutes: 1)),
+      setLastAlarmAt: true,
+      setSnoozedUntil: true,
+      snoozedUntil: now.add(const Duration(minutes: 4)),
+    );
+
+    network._result = ThermostatFetchSuccess(
+      valueC: 4.5,
+      fetchedAt: now,
+      etag: 'etag-3',
+    );
+
+    final runner = ThermostatMonitorRunner(
+      repository: repository,
+      network: network,
+      alarmDispatcher: alarms,
+      clock: () => now,
+    );
+
+    await runner.run();
+
+    final state = await repository.loadState(thermostat.id);
+    expect(state, isNotNull);
+    expect(state!.status, ThermostatReadingStatus.outOfRange);
+    expect(state.lastAlarmAt, now.subtract(const Duration(minutes: 1)));
+    expect(state.snoozedUntil, now.add(const Duration(minutes: 4)));
+    expect(alarms.triggered, isEmpty);
   });
 }

--- a/app/test/unit/thermostat_monitor_runner_test.dart
+++ b/app/test/unit/thermostat_monitor_runner_test.dart
@@ -157,62 +157,64 @@ void main() {
     expect(alarms.triggered, isEmpty);
   });
 
-  test('run clears narrow-range hysteresis alarm when value returns in range',
-      () async {
-    final thermostat = await repository.create(
-      ThermostatDraft(
-        name: 'Nursery',
-        rawUrl: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-        minC: 19,
-        maxC: 20,
-      ),
-    );
+  test(
+    'run clears narrow-range hysteresis alarm when value returns in range',
+    () async {
+      final thermostat = await repository.create(
+        ThermostatDraft(
+          name: 'Nursery',
+          rawUrl: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+          minC: 19,
+          maxC: 20,
+        ),
+      );
 
-    await database.upsertThermostat(
-      ThermostatEntriesCompanion(
-        id: drift.Value(thermostat.id),
-        name: drift.Value(thermostat.name),
-        rawUrl: drift.Value(thermostat.rawUrl),
-        minC: drift.Value(thermostat.minC),
-        maxC: drift.Value(thermostat.maxC),
-        hysteresisEnabled: const drift.Value(true),
-        monitoringEnabled: drift.Value(thermostat.monitoringEnabled),
-        createdAt: drift.Value(thermostat.createdAt),
-        updatedAt: drift.Value(thermostat.updatedAt),
-      ),
-    );
+      await database.upsertThermostat(
+        ThermostatEntriesCompanion(
+          id: drift.Value(thermostat.id),
+          name: drift.Value(thermostat.name),
+          rawUrl: drift.Value(thermostat.rawUrl),
+          minC: drift.Value(thermostat.minC),
+          maxC: drift.Value(thermostat.maxC),
+          hysteresisEnabled: const drift.Value(true),
+          monitoringEnabled: drift.Value(thermostat.monitoringEnabled),
+          createdAt: drift.Value(thermostat.createdAt),
+          updatedAt: drift.Value(thermostat.updatedAt),
+        ),
+      );
 
-    await repository.saveState(
-      thermostatId: thermostat.id,
-      status: ThermostatReadingStatus.outOfRange,
-      valueC: 21,
-      fetchedAt: DateTime.utc(2025, 1, 1, 11, 55),
-      etag: 'etag',
-      message: 'Out of range',
-    );
+      await repository.saveState(
+        thermostatId: thermostat.id,
+        status: ThermostatReadingStatus.outOfRange,
+        valueC: 21,
+        fetchedAt: DateTime.utc(2025, 1, 1, 11, 55),
+        etag: 'etag',
+        message: 'Out of range',
+      );
 
-    network._result = ThermostatFetchSuccess(
-      valueC: 19.6,
-      fetchedAt: DateTime.utc(2025, 1, 1, 12),
-      etag: 'etag-2',
-    );
+      network._result = ThermostatFetchSuccess(
+        valueC: 19.6,
+        fetchedAt: DateTime.utc(2025, 1, 1, 12),
+        etag: 'etag-2',
+      );
 
-    final runner = ThermostatMonitorRunner(
-      repository: repository,
-      network: network,
-      alarmDispatcher: alarms,
-      clock: () => DateTime.utc(2025, 1, 1, 12, 1),
-    );
+      final runner = ThermostatMonitorRunner(
+        repository: repository,
+        network: network,
+        alarmDispatcher: alarms,
+        clock: () => DateTime.utc(2025, 1, 1, 12, 1),
+      );
 
-    await runner.run();
+      await runner.run();
 
-    final state = await repository.loadState(thermostat.id);
-    expect(state, isNotNull);
-    expect(state!.status, ThermostatReadingStatus.ok);
-    expect(state.lastValueC, 19.6);
-    expect(state.statusMessage, 'Fetched 19.6°C');
-    expect(alarms.triggered, isEmpty);
-  });
+      final state = await repository.loadState(thermostat.id);
+      expect(state, isNotNull);
+      expect(state!.status, ThermostatReadingStatus.ok);
+      expect(state.lastValueC, 19.6);
+      expect(state.statusMessage, 'Fetched 19.6°C');
+      expect(alarms.triggered, isEmpty);
+    },
+  );
 
   test('run respects snooze window', () async {
     final thermostat = await repository.create(

--- a/app/test/unit/thermostat_monitor_runner_test.dart
+++ b/app/test/unit/thermostat_monitor_runner_test.dart
@@ -1,3 +1,4 @@
+import 'package:drift/drift.dart' as drift;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -153,6 +154,63 @@ void main() {
     expect(state!.status, ThermostatReadingStatus.networkError);
     expect(state.statusMessage, 'network down');
     expect(state.lastFetchedAt, DateTime.utc(2025, 1, 1, 13));
+    expect(alarms.triggered, isEmpty);
+  });
+
+  test('run clears narrow-range hysteresis alarm when value returns in range',
+      () async {
+    final thermostat = await repository.create(
+      ThermostatDraft(
+        name: 'Nursery',
+        rawUrl: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+        minC: 19,
+        maxC: 20,
+      ),
+    );
+
+    await database.upsertThermostat(
+      ThermostatEntriesCompanion(
+        id: drift.Value(thermostat.id),
+        name: drift.Value(thermostat.name),
+        rawUrl: drift.Value(thermostat.rawUrl),
+        minC: drift.Value(thermostat.minC),
+        maxC: drift.Value(thermostat.maxC),
+        hysteresisEnabled: const drift.Value(true),
+        monitoringEnabled: drift.Value(thermostat.monitoringEnabled),
+        createdAt: drift.Value(thermostat.createdAt),
+        updatedAt: drift.Value(thermostat.updatedAt),
+      ),
+    );
+
+    await repository.saveState(
+      thermostatId: thermostat.id,
+      status: ThermostatReadingStatus.outOfRange,
+      valueC: 21,
+      fetchedAt: DateTime.utc(2025, 1, 1, 11, 55),
+      etag: 'etag',
+      message: 'Out of range',
+    );
+
+    network._result = ThermostatFetchSuccess(
+      valueC: 19.6,
+      fetchedAt: DateTime.utc(2025, 1, 1, 12),
+      etag: 'etag-2',
+    );
+
+    final runner = ThermostatMonitorRunner(
+      repository: repository,
+      network: network,
+      alarmDispatcher: alarms,
+      clock: () => DateTime.utc(2025, 1, 1, 12, 1),
+    );
+
+    await runner.run();
+
+    final state = await repository.loadState(thermostat.id);
+    expect(state, isNotNull);
+    expect(state!.status, ThermostatReadingStatus.ok);
+    expect(state.lastValueC, 19.6);
+    expect(state.statusMessage, 'Fetched 19.6°C');
     expect(alarms.triggered, isEmpty);
   });
 

--- a/app/test/unit/thermostat_repository_test.dart
+++ b/app/test/unit/thermostat_repository_test.dart
@@ -126,6 +126,8 @@ void main() {
     expect(state!.status, ThermostatReadingStatus.ok);
     expect(state.lastValueC, 9.5);
     expect(state.statusMessage, 'Fetched 9.5°C');
+    expect(state.snoozedUntil, isNull);
+    expect(state.silenceUntilOk, isFalse);
 
     await repository.saveState(
       thermostatId: thermostat.id,
@@ -142,4 +144,45 @@ void main() {
     expect(state.lastValueC, 9.5);
     expect(state.statusMessage, 'Failed with status 500');
   });
+
+  test(
+    'updateSnoozedUntil and updateSilenceUntilOk persist controls',
+    () async {
+      final thermostat = await repository.create(
+        ThermostatDraft(
+          name: 'Lab',
+          rawUrl: '99999999999999999999999999999999',
+          minC: 4,
+          maxC: 18,
+        ),
+      );
+
+      final now = DateTime.utc(2025, 1, 2, 10);
+      await repository.saveState(
+        thermostatId: thermostat.id,
+        status: ThermostatReadingStatus.outOfRange,
+        valueC: 2.0,
+        fetchedAt: now,
+        etag: null,
+        message: 'Too cold',
+        setSnoozedUntil: true,
+        snoozedUntil: now.add(const Duration(minutes: 15)),
+      );
+
+      var state = await repository.loadState(thermostat.id);
+      expect(state, isNotNull);
+      expect(state!.snoozedUntil, now.add(const Duration(minutes: 15)));
+      expect(state.silenceUntilOk, isFalse);
+
+      await repository.updateSilenceUntilOk(thermostat.id, true);
+      state = await repository.loadState(thermostat.id);
+      expect(state, isNotNull);
+      expect(state!.silenceUntilOk, isTrue);
+
+      await repository.updateSnoozedUntil(thermostat.id, null);
+      state = await repository.loadState(thermostat.id);
+      expect(state, isNotNull);
+      expect(state!.snoozedUntil, isNull);
+    },
+  );
 }


### PR DESCRIPTION
## Summary
- add range evaluation, rate limiting, and notification actions to the background monitor
- extend the thermostat schema and repository to persist alarm state, snooze, and silence controls
- add a full-screen alarm page and routing so notification taps surface actionable UI

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68ecf9923d8c832588640486b279f6da