### PR TITLE
Improve thermostat refresh flow and coverage

### DIFF
--- a/app/lib/core/background/thermostat_monitor.dart
+++ b/app/lib/core/background/thermostat_monitor.dart
@@ -8,6 +8,7 @@ import 'package:workmanager/workmanager.dart';
 
 import '../../features/thermostats/data/thermostat_client.dart';
 import '../../features/thermostats/data/thermostat_database.dart';
+import '../../features/thermostats/data/thermostat_reading_utils.dart';
 import '../../features/thermostats/data/thermostat_repository.dart';
 import '../../features/thermostats/models/thermostat.dart';
 import '../../features/thermostats/models/thermostat_state.dart';
@@ -131,14 +132,17 @@ class ThermostatMonitorRunner {
         final result = await _network.fetchCurrent(thermostat.rawUrl);
         final value = result.valueC;
         final fetchedAt = result.fetchedAt;
-        final outOfRange = _isOutOfRange(
+        final outOfRange = isThermostatReadingOutOfRange(
           thermostat: thermostat,
           currentValue: value,
           previousState: previousState,
         );
         if (outOfRange) {
           final now = _clock();
-          final baseMessage = _formatOutOfRangeMessage(thermostat, value);
+          final baseMessage = formatOutOfRangeThermostatMessage(
+            thermostat,
+            value,
+          );
           final shouldAlarm = _shouldTriggerAlarm(previousState, now);
           final clearSnooze =
               shouldAlarm && (previousState?.snoozedUntil != null);
@@ -205,33 +209,6 @@ class ThermostatMonitorRunner {
     }
   }
 
-  bool _isOutOfRange({
-    required Thermostat thermostat,
-    required double currentValue,
-    ThermostatState? previousState,
-  }) {
-    final min = thermostat.minC;
-    final max = thermostat.maxC;
-    if (!thermostat.hysteresisEnabled) {
-      return currentValue < min || currentValue > max;
-    }
-
-    final previouslyOut =
-        previousState?.status == ThermostatReadingStatus.outOfRange;
-    if (!previouslyOut) {
-      return currentValue < min || currentValue > max;
-    }
-
-    final bufferMin = min + 1.0;
-    final bufferMax = max - 1.0;
-    if (bufferMin <= bufferMax) {
-      return currentValue < bufferMin || currentValue > bufferMax;
-    }
-
-    // Range is narrower than hysteresis buffer; fall back to inclusive bounds.
-    return currentValue < min || currentValue > max;
-  }
-
   bool _shouldTriggerAlarm(ThermostatState? previousState, DateTime now) {
     if (previousState == null) {
       return true;
@@ -256,11 +233,6 @@ class ThermostatMonitorRunner {
     }
 
     return true;
-  }
-
-  String _formatOutOfRangeMessage(Thermostat thermostat, double valueC) {
-    return 'Out of range: ${valueC.toStringAsFixed(1)}°C '
-        '(${thermostat.minC.toStringAsFixed(1)}°C – ${thermostat.maxC.toStringAsFixed(1)}°C)';
   }
 }
 

--- a/app/lib/features/thermostats/data/thermostat_reading_utils.dart
+++ b/app/lib/features/thermostats/data/thermostat_reading_utils.dart
@@ -1,0 +1,35 @@
+import '../models/thermostat.dart';
+import '../models/thermostat_state.dart';
+
+bool isThermostatReadingOutOfRange({
+  required Thermostat thermostat,
+  required double currentValue,
+  ThermostatState? previousState,
+}) {
+  final min = thermostat.minC;
+  final max = thermostat.maxC;
+  if (!thermostat.hysteresisEnabled) {
+    return currentValue < min || currentValue > max;
+  }
+
+  final previouslyOut =
+      previousState?.status == ThermostatReadingStatus.outOfRange;
+  if (!previouslyOut) {
+    return currentValue < min || currentValue > max;
+  }
+
+  final bufferMin = min + 1.0;
+  final bufferMax = max - 1.0;
+  if (bufferMin <= bufferMax) {
+    return currentValue < bufferMin || currentValue > bufferMax;
+  }
+
+  // Range is narrower than hysteresis buffer; fall back to inclusive bounds.
+  return currentValue < min || currentValue > max;
+}
+
+String formatOutOfRangeThermostatMessage(Thermostat thermostat, double valueC) {
+  return 'Out of range: ${valueC.toStringAsFixed(1)}°C '
+      '(${thermostat.minC.toStringAsFixed(1)}°C – '
+      '${thermostat.maxC.toStringAsFixed(1)}°C)';
+}

--- a/app/lib/features/thermostats/data/thermostat_service.dart
+++ b/app/lib/features/thermostats/data/thermostat_service.dart
@@ -1,6 +1,7 @@
 import '../models/thermostat.dart';
 import '../models/thermostat_state.dart';
 import 'thermostat_client.dart';
+import 'thermostat_reading_utils.dart';
 import 'thermostat_repository.dart';
 
 class ThermostatService {
@@ -53,4 +54,108 @@ class ThermostatService {
     );
     return updated;
   }
+
+  Future<ThermostatRefreshResult> refresh(Thermostat thermostat) async {
+    final previousState = await _repository.loadState(thermostat.id);
+    try {
+      final result = await _network.fetchCurrent(thermostat.rawUrl.trim());
+      final value = result.valueC;
+      final fetchedAt = result.fetchedAt;
+      final outOfRange = isThermostatReadingOutOfRange(
+        thermostat: thermostat,
+        currentValue: value,
+        previousState: previousState,
+      );
+      if (outOfRange) {
+        final message = formatOutOfRangeThermostatMessage(thermostat, value);
+        await _repository.saveState(
+          thermostatId: thermostat.id,
+          status: ThermostatReadingStatus.outOfRange,
+          valueC: value,
+          fetchedAt: fetchedAt,
+          etag: result.etag,
+          message: message,
+        );
+        return ThermostatRefreshResult(
+          status: ThermostatReadingStatus.outOfRange,
+          message: message,
+          valueC: value,
+          fetchedAt: fetchedAt,
+        );
+      }
+
+      final message = 'Fetched ${value.toStringAsFixed(1)}°C';
+      final shouldClearSnooze = previousState?.snoozedUntil != null;
+      final hadSilence = previousState?.silenceUntilOk == true;
+      await _repository.saveState(
+        thermostatId: thermostat.id,
+        status: ThermostatReadingStatus.ok,
+        valueC: value,
+        fetchedAt: fetchedAt,
+        etag: result.etag,
+        message: message,
+        setSnoozedUntil: shouldClearSnooze,
+        snoozedUntil: null,
+        setSilenceUntilOk: hadSilence,
+        silenceUntilOk: false,
+      );
+      return ThermostatRefreshResult(
+        status: ThermostatReadingStatus.ok,
+        message: message,
+        valueC: value,
+        fetchedAt: fetchedAt,
+      );
+    } on ThermostatFetchException catch (error) {
+      final now = DateTime.now().toUtc();
+      await _repository.saveState(
+        thermostatId: thermostat.id,
+        status: error.status,
+        valueC: previousState?.lastValueC,
+        fetchedAt: now,
+        etag: previousState?.etag,
+        message: error.message,
+      );
+      return ThermostatRefreshResult(
+        status: error.status,
+        message: error.message,
+        valueC: previousState?.lastValueC,
+        fetchedAt: now,
+      );
+    } catch (error) {
+      final now = DateTime.now().toUtc();
+      final message = 'Unexpected error: $error';
+      await _repository.saveState(
+        thermostatId: thermostat.id,
+        status: ThermostatReadingStatus.unknown,
+        valueC: previousState?.lastValueC,
+        fetchedAt: now,
+        etag: previousState?.etag,
+        message: message,
+      );
+      return ThermostatRefreshResult(
+        status: ThermostatReadingStatus.unknown,
+        message: message,
+        valueC: previousState?.lastValueC,
+        fetchedAt: now,
+      );
+    }
+  }
+}
+
+class ThermostatRefreshResult {
+  const ThermostatRefreshResult({
+    required this.status,
+    required this.message,
+    this.valueC,
+    required this.fetchedAt,
+  });
+
+  final ThermostatReadingStatus status;
+  final String message;
+  final double? valueC;
+  final DateTime fetchedAt;
+
+  bool get isSuccess =>
+      status == ThermostatReadingStatus.ok ||
+      status == ThermostatReadingStatus.outOfRange;
 }

--- a/app/lib/features/thermostats/view/thermostats_page.dart
+++ b/app/lib/features/thermostats/view/thermostats_page.dart
@@ -56,6 +56,42 @@ class ThermostatsPage extends ConsumerWidget {
     ).showSnackBar(const SnackBar(content: Text('Thermostat updated.')));
   }
 
+  Future<void> _refreshThermostat(
+    BuildContext context,
+    WidgetRef ref,
+    ThermostatSummary summary,
+  ) async {
+    final service = ref.read(thermostatServiceProvider);
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final result = await service.refresh(summary.thermostat);
+      if (!context.mounted) {
+        return;
+      }
+      final thermostatName = summary.thermostat.name;
+      final message = '$thermostatName: ${result.message}';
+      final isError = switch (result.status) {
+        ThermostatReadingStatus.ok => false,
+        _ => true,
+      };
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(message),
+          backgroundColor: isError ? Theme.of(context).colorScheme.error : null,
+        ),
+      );
+    } catch (error) {
+      if (!context.mounted) {
+        return;
+      }
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text('Failed to refresh ${summary.thermostat.name}: $error'),
+        ),
+      );
+    }
+  }
+
   Future<void> _deleteThermostat(
     BuildContext context,
     WidgetRef ref,
@@ -129,6 +165,7 @@ class ThermostatsPage extends ConsumerWidget {
                 summary: summary,
                 onEdit: () => _editThermostat(context, ref, summary),
                 onDelete: () => _deleteThermostat(context, ref, summary),
+                onRefresh: () => _refreshThermostat(context, ref, summary),
               );
             },
             separatorBuilder: (context, index) => const SizedBox(height: 12),

--- a/app/lib/features/thermostats/widgets/thermostat_card.dart
+++ b/app/lib/features/thermostats/widgets/thermostat_card.dart
@@ -7,12 +7,14 @@ class ThermostatCard extends StatelessWidget {
     required this.summary,
     this.onEdit,
     this.onDelete,
+    this.onRefresh,
     super.key,
   });
 
   final ThermostatSummary summary;
   final VoidCallback? onEdit;
   final VoidCallback? onDelete;
+  final VoidCallback? onRefresh;
 
   @override
   Widget build(BuildContext context) {
@@ -47,6 +49,12 @@ class ThermostatCard extends StatelessWidget {
                     ],
                   ),
                 ),
+                if (onRefresh != null)
+                  IconButton(
+                    onPressed: onRefresh,
+                    tooltip: 'Refresh',
+                    icon: const Icon(Icons.refresh),
+                  ),
                 if (onEdit != null || onDelete != null)
                   PopupMenuButton<_ThermostatMenuAction>(
                     onSelected: (value) {

--- a/app/test/unit/thermostat_service_test.dart
+++ b/app/test/unit/thermostat_service_test.dart
@@ -13,9 +13,14 @@ class _FakeNetworkDataSource implements ThermostatNetworkDataSource {
 
   ThermostatFetchSuccess? _result;
   ThermostatFetchException? _exception;
+  Object? _otherError;
 
   @override
   Future<ThermostatFetchSuccess> fetchCurrent(String url) async {
+    final otherError = _otherError;
+    if (otherError != null) {
+      throw otherError;
+    }
     if (_exception != null) {
       throw _exception!;
     }
@@ -123,5 +128,135 @@ void main() {
 
     final summaries = await repository.fetchThermostats();
     expect(summaries, isEmpty);
+  });
+
+  group('refresh', () {
+    late Thermostat thermostat;
+
+    setUp(() async {
+      thermostat = await repository.create(
+        ThermostatDraft(
+          name: 'Refreshable',
+          rawUrl: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+          minC: 10,
+          maxC: 20,
+        ),
+      );
+    });
+
+    test('refresh stores latest value and clears snooze and silence', () async {
+      await repository.saveState(
+        thermostatId: thermostat.id,
+        status: ThermostatReadingStatus.outOfRange,
+        valueC: 30,
+        fetchedAt: DateTime.utc(2025, 1, 1, 9),
+        etag: 'old',
+        message: 'Out of range',
+        snoozedUntil: DateTime.utc(2025, 1, 1, 10),
+        setSnoozedUntil: true,
+        silenceUntilOk: true,
+        setSilenceUntilOk: true,
+      );
+
+      network._result = ThermostatFetchSuccess(
+        valueC: 18.4,
+        fetchedAt: DateTime.utc(2025, 1, 1, 11),
+        etag: 'new',
+      );
+
+      final result = await service.refresh(thermostat);
+
+      expect(result.status, ThermostatReadingStatus.ok);
+      expect(result.message, 'Fetched 18.4°C');
+      expect(result.valueC, 18.4);
+
+      final state = await repository.loadState(thermostat.id);
+      expect(state, isNotNull);
+      expect(state!.status, ThermostatReadingStatus.ok);
+      expect(state.lastValueC, 18.4);
+      expect(state.lastFetchedAt, result.fetchedAt);
+      expect(state.statusMessage, 'Fetched 18.4°C');
+      expect(state.snoozedUntil, isNull);
+      expect(state.silenceUntilOk, isFalse);
+    });
+
+    test(
+      'refresh marks out of range when temperature outside bounds',
+      () async {
+        network._result = ThermostatFetchSuccess(
+          valueC: 25.2,
+          fetchedAt: DateTime.utc(2025, 1, 2, 12),
+          etag: 'etag',
+        );
+
+        final result = await service.refresh(thermostat);
+
+        expect(result.status, ThermostatReadingStatus.outOfRange);
+        expect(result.message, 'Out of range: 25.2°C (10.0°C – 20.0°C)');
+        expect(result.valueC, 25.2);
+
+        final state = await repository.loadState(thermostat.id);
+        expect(state, isNotNull);
+        expect(state!.status, ThermostatReadingStatus.outOfRange);
+        expect(state.lastValueC, 25.2);
+        expect(state.statusMessage, 'Out of range: 25.2°C (10.0°C – 20.0°C)');
+      },
+    );
+
+    test('refresh persists fetch errors with previous value', () async {
+      await repository.saveState(
+        thermostatId: thermostat.id,
+        status: ThermostatReadingStatus.ok,
+        valueC: 15.0,
+        fetchedAt: DateTime.utc(2025, 1, 3, 7),
+        etag: 'etag',
+        message: 'Fetched 15.0°C',
+      );
+
+      network._exception = const ThermostatFetchException(
+        status: ThermostatReadingStatus.networkError,
+        message: 'Network down',
+      );
+
+      final result = await service.refresh(thermostat);
+
+      expect(result.status, ThermostatReadingStatus.networkError);
+      expect(result.message, 'Network down');
+      expect(result.valueC, 15.0);
+
+      final state = await repository.loadState(thermostat.id);
+      expect(state, isNotNull);
+      expect(state!.status, ThermostatReadingStatus.networkError);
+      expect(state.lastValueC, 15.0);
+      expect(state.statusMessage, 'Network down');
+      final persistedFetchedAt = state.lastFetchedAt;
+      expect(persistedFetchedAt, isNotNull);
+      expect(
+        persistedFetchedAt!.difference(result.fetchedAt).inMilliseconds.abs(),
+        lessThan(1000),
+      );
+    });
+
+    test('refresh guards against unexpected errors', () async {
+      network._otherError = Exception('boom');
+
+      final result = await service.refresh(thermostat);
+
+      expect(result.status, ThermostatReadingStatus.unknown);
+      expect(result.message, 'Unexpected error: Exception: boom');
+      expect(result.valueC, isNull);
+
+      final state = await repository.loadState(thermostat.id);
+      expect(state, isNotNull);
+      expect(state!.status, ThermostatReadingStatus.unknown);
+      expect(state.lastValueC, isNull);
+      expect(state.statusMessage, 'Unexpected error: Exception: boom');
+      final persistedFetchedAt = state.lastFetchedAt;
+      expect(persistedFetchedAt, isNotNull);
+      expect(
+        persistedFetchedAt!.difference(result.fetchedAt).inMilliseconds.abs(),
+        lessThan(1000),
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary
- share thermostat range evaluation helpers so the background monitor and refresh workflow reuse the same logic
- update the thermostat service refresh path to use the shared helpers while keeping snooze and silence flags in sync
- add unit tests that exercise success, out-of-range, fetch-error, and unexpected-error refresh scenarios

## Testing
- flutter analyze
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68ed4295d80c8325a3be932fe697732f