### PR TITLE
Iteration 10 offline resilience and retention hardening

### DIFF
--- a/.agent/ExecPlan.md
+++ b/.agent/ExecPlan.md
@@ -85,6 +85,9 @@ Use ☐/[-]/✅ with UTC timestamps to reflect real progress.
 - ☐ `[2025-10-17 16:00Z]` Gate A reliability validation and decision.
 - ✅ `[2025-10-18 16:00Z]` Normalize revision history storage, add detail chart with downsampling for long ranges.
 - ✅ `[2025-10-19 14:00Z]` Completed iteration 8 settings deliverables: system sound picker with persisted permissions and developer log export refinements.
+- ✅ `[2025-10-20 16:00Z]` Hardened offline experience with connectivity heuristics, banner UX, and unit tests for status detection.
+- ✅ `[2025-10-20 16:45Z]` Implemented history retention pruning (18-month window + entry cap) wired into foreground and background refresh paths.
+- ✅ `[2025-10-20 17:15Z]` Added accessibility semantics, localization delegates, and release-ready documentation updates.
 
 ### Executive Summary (current)
 - Created supported Flutter app under `app/` with Material 3 + Riverpod and bottom navigation.
@@ -97,6 +100,7 @@ Use ☐/[-]/✅ with UTC timestamps to reflect real progress.
 - Normalized thermostat timestamps to UTC to avoid device/timezone skew and simplify comparisons.
 - Registered plugins in the background isolate (no native code) to enable notifications and path provider.
 - Switched to GitHub Gist API with Gist ID–only configuration; simplified client and tests.
+- Delivered offline-aware UI, retention pruning, and accessibility/localization polish to reach iteration 10 release readiness.
 
 ---
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, master]
   pull_request:
 
 jobs:
@@ -59,3 +59,29 @@ jobs:
           name: farmctl-debug-apk
           path: app/build/app/outputs/flutter-apk/app-debug.apk
           if-no-files-found: error
+
+      - name: Assemble release APK
+        if: github.ref == 'refs/heads/master'
+        run: flutter build apk --release
+        working-directory: app
+
+      - name: Create GitHub release
+        if: github.ref == 'refs/heads/master'
+        id: create_release
+        uses: actions/create-release@v1
+        with:
+          tag_name: release-${{ github.run_number }}
+          release_name: FarmCtl Release ${{ github.run_number }}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload release APK asset
+        if: github.ref == 'refs/heads/master'
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: app/build/app/outputs/flutter-apk/app-release.apk
+          asset_name: farmctl-release-${{ github.run_number }}.apk
+          asset_content_type: application/vnd.android.package-archive

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Run the automated checks before pushing to ensure the CI workflow will pass:
 ```bash
 cd app
 flutter pub get
+flutter pub run build_runner build --delete-conflicting-outputs
 dart format .
 flutter analyze
 flutter test
@@ -52,6 +53,10 @@ flutter build apk --debug
 cd ../packages/farmctl_parsing
 dart test
 ```
+
+> **Note:** Generated Drift and Freezed code is intentionally `.gitignore`d. Run the `build_runner` command above whenever you
+> pull new changes or modify source files that rely on code generation so that `flutter analyze` and the test suite have access
+> to the necessary artifacts.
 
 The repository includes a [`.pre-commit-config.yaml`](.pre-commit-config.yaml) that formats changed Dart files and runs `flutter analyze`. After installing [`pre-commit`](https://pre-commit.com/#install), enable the hooks with `pre-commit install`.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,12 @@ flutter pub get
 flutter run
 ```
 
-The application launches with Material 3 theming, Riverpod-provided state management, and a bottom navigation bar exposing the Thermostats and Settings tabs. The Thermostats tab shows a static thermostat card that will be replaced with live data in future iterations.
+The application launches with Material 3 theming and Riverpod-provided state management. The Thermostats tab lists every configured sensor with live status, last-known values, and range context. Background monitoring keeps readings fresh, and an offline banner surfaces when connectivity drops so users know they are viewing cached data. Settings exposes polling cadence, alarm options, and GitHub token management.
+
+### Key capabilities
+- Offline-aware UI that highlights degraded connectivity while continuing to show the last known readings.
+- Automatic retention pruning that keeps roughly 18 months of history per thermostat so the on-device database remains lightweight.
+- Accessibility improvements including localization scaffolding (English) and enhanced semantics for thermostat cards and history charts.
 
 ### Quality Checks
 

--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'core/router/app_router.dart';
@@ -20,6 +21,12 @@ class FarmCtlApp extends ConsumerWidget {
         useMaterial3: true,
         appBarTheme: AppBarTheme(backgroundColor: colorScheme.surface),
       ),
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en')],
       routerConfig: router,
     );
   }

--- a/app/lib/core/background/thermostat_monitor.dart
+++ b/app/lib/core/background/thermostat_monitor.dart
@@ -224,6 +224,13 @@ Future<void> _runMonitorTask() async {
         debugPrint('$stackTrace');
       }
     }
+
+    try {
+      await repository.pruneRetention();
+    } catch (error, stackTrace) {
+      debugPrint('Retention pruning failed in background: $error');
+      debugPrint('$stackTrace');
+    }
   } catch (error, stackTrace) {
     debugPrint('Thermostat monitor failed: $error');
     debugPrint('$stackTrace');

--- a/app/lib/features/thermostats/data/thermostat_database.dart
+++ b/app/lib/features/thermostats/data/thermostat_database.dart
@@ -374,6 +374,37 @@ class ThermostatDatabase extends _$ThermostatDatabase {
     }
   }
 
+  Future<int> pruneTemperatureReadingsBefore(DateTime cutoff) {
+    return (delete(
+      temperatureReadings,
+    )..where((tbl) => tbl.observedAt.isSmallerThanValue(cutoff))).go();
+  }
+
+  Future<void> pruneTemperatureReadingsExceedingLimit(
+    String thermostatId,
+    int keepLatest,
+  ) async {
+    if (keepLatest <= 0) {
+      await (delete(
+        temperatureReadings,
+      )..where((tbl) => tbl.thermostatId.equals(thermostatId))).go();
+      return;
+    }
+
+    await customStatement(
+      '''
+      DELETE FROM temperature_readings
+      WHERE thermostat_id = ? AND id NOT IN (
+        SELECT id FROM temperature_readings
+        WHERE thermostat_id = ?
+        ORDER BY observed_at DESC, id DESC
+        LIMIT ?
+      )
+      ''',
+      [thermostatId, thermostatId, keepLatest],
+    );
+  }
+
   AlertConfigEntry _defaultAlertConfig() {
     return AlertConfigEntry(
       id: 1,

--- a/app/lib/features/thermostats/data/thermostat_repository.dart
+++ b/app/lib/features/thermostats/data/thermostat_repository.dart
@@ -7,6 +7,8 @@ import '../models/thermostat_state.dart';
 import 'thermostat_database.dart';
 
 final _uuid = const Uuid();
+const Duration _defaultRetentionMaxAge = Duration(days: 548);
+const int _defaultRetentionMaxEntries = 5000;
 
 class ThermostatRepository {
   ThermostatRepository(this._database);
@@ -290,5 +292,30 @@ class ThermostatRepository {
 
   Future<Set<String>> listKnownRevisionIds(String thermostatId) {
     return _database.listKnownRevisionIds(thermostatId);
+  }
+
+  Future<void> pruneRetention({
+    Duration maxAge = _defaultRetentionMaxAge,
+    int maxEntriesPerThermostat = _defaultRetentionMaxEntries,
+    String? thermostatId,
+    DateTime? now,
+  }) async {
+    final referenceTime = (now ?? DateTime.now()).toUtc();
+
+    if (maxAge > Duration.zero) {
+      final cutoff = referenceTime.subtract(maxAge);
+      await _database.pruneTemperatureReadingsBefore(cutoff);
+    }
+
+    final ids = thermostatId != null
+        ? <String>[thermostatId]
+        : (await _database.listThermostats()).map((entry) => entry.id).toList();
+
+    for (final id in ids) {
+      await _database.pruneTemperatureReadingsExceedingLimit(
+        id,
+        maxEntriesPerThermostat,
+      );
+    }
   }
 }

--- a/app/lib/features/thermostats/data/thermostat_service.dart
+++ b/app/lib/features/thermostats/data/thermostat_service.dart
@@ -1,4 +1,5 @@
 import 'dart:io' show Platform;
+import 'package:flutter/foundation.dart';
 import '../models/temperature_sample.dart';
 import '../models/thermostat.dart';
 import '../models/thermostat_state.dart';
@@ -318,6 +319,13 @@ class ThermostatService {
       thermostatId: thermostatId,
       samples: samples,
     );
+
+    try {
+      await _repository.pruneRetention(thermostatId: thermostatId);
+    } catch (error, stackTrace) {
+      debugPrint('Retention pruning failed for $thermostatId: $error');
+      debugPrint('$stackTrace');
+    }
   }
 
   String _timeBucketKey(DateTime t, Duration interval) {

--- a/app/lib/features/thermostats/providers/thermostat_providers.dart
+++ b/app/lib/features/thermostats/providers/thermostat_providers.dart
@@ -114,6 +114,59 @@ final thermostatHistoryRefreshProvider = FutureProvider.autoDispose
       );
     });
 
+enum OfflineStatus { online, degraded, offline, unknown }
+
+final offlineStatusProvider = Provider<OfflineStatus>((ref) {
+  final thermostatsAsync = ref.watch(thermostatsProvider);
+  return thermostatsAsync.when(
+    data: (thermostats) {
+      if (thermostats.isEmpty) {
+        return OfflineStatus.online;
+      }
+
+      final now = DateTime.now().toUtc();
+      var recentNetworkFailures = 0;
+      var recentSuccess = false;
+
+      for (final summary in thermostats) {
+        final state = summary.state;
+        if (state == null) {
+          continue;
+        }
+
+        final lastFetchedAt = state.lastFetchedAt;
+        switch (state.status) {
+          case ThermostatReadingStatus.ok:
+          case ThermostatReadingStatus.outOfRange:
+            if (lastFetchedAt != null &&
+                now.difference(lastFetchedAt) <= const Duration(minutes: 15)) {
+              recentSuccess = true;
+            }
+            break;
+          case ThermostatReadingStatus.networkError:
+            if (lastFetchedAt != null &&
+                now.difference(lastFetchedAt) <= const Duration(minutes: 30)) {
+              recentNetworkFailures += 1;
+            }
+            break;
+          case ThermostatReadingStatus.httpError:
+          case ThermostatReadingStatus.parseError:
+          case ThermostatReadingStatus.unknown:
+            break;
+        }
+      }
+
+      if (recentNetworkFailures == 0) {
+        return OfflineStatus.online;
+      }
+
+      return recentSuccess ? OfflineStatus.degraded : OfflineStatus.offline;
+    },
+    loading: () => OfflineStatus.unknown,
+    error: (error, stackTrace) => OfflineStatus.unknown,
+  );
+});
+
 class _RefreshThrottleRegistry {
   final Map<String, DateTime> lastRun = <String, DateTime>{};
 }

--- a/app/lib/features/thermostats/view/thermostats_page.dart
+++ b/app/lib/features/thermostats/view/thermostats_page.dart
@@ -162,40 +162,122 @@ class ThermostatsPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final asyncThermostats = ref.watch(thermostatsProvider);
+    final offlineStatus = ref.watch(offlineStatusProvider);
+
+    final content = asyncThermostats.when(
+      data: (thermostats) {
+        if (thermostats.isEmpty) {
+          return const _EmptyState();
+        }
+
+        return ListView.separated(
+          padding: const EdgeInsets.all(16),
+          itemBuilder: (context, index) {
+            final summary = thermostats[index];
+            return ThermostatCard(
+              summary: summary,
+              onEdit: () => _editThermostat(context, ref, summary),
+              onDelete: () => _deleteThermostat(context, ref, summary),
+              onRefresh: () => _refreshThermostat(context, ref, summary),
+              onTap: () => context.pushNamed(
+                ThermostatDetailRoute.name,
+                pathParameters: {'id': summary.thermostat.id},
+              ),
+            );
+          },
+          separatorBuilder: (context, index) => const SizedBox(height: 12),
+          itemCount: thermostats.length,
+        );
+      },
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, stackTrace) => _ErrorState(error: error),
+    );
 
     return Scaffold(
       appBar: AppBar(title: const Text('Thermostats')),
-      body: asyncThermostats.when(
-        data: (thermostats) {
-          if (thermostats.isEmpty) {
-            return const _EmptyState();
-          }
-
-          return ListView.separated(
-            padding: const EdgeInsets.all(16),
-            itemBuilder: (context, index) {
-              final summary = thermostats[index];
-              return ThermostatCard(
-                summary: summary,
-                onEdit: () => _editThermostat(context, ref, summary),
-                onDelete: () => _deleteThermostat(context, ref, summary),
-                onRefresh: () => _refreshThermostat(context, ref, summary),
-                onTap: () => context.pushNamed(
-                  ThermostatDetailRoute.name,
-                  pathParameters: {'id': summary.thermostat.id},
-                ),
-              );
-            },
-            separatorBuilder: (context, index) => const SizedBox(height: 12),
-            itemCount: thermostats.length,
-          );
-        },
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (error, stackTrace) => _ErrorState(error: error),
+      body: Column(
+        children: [
+          if (offlineStatus == OfflineStatus.offline ||
+              offlineStatus == OfflineStatus.degraded)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+              child: _OfflineBanner(status: offlineStatus),
+            ),
+          Expanded(child: content),
+        ],
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () => _createThermostat(context, ref),
         child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+
+class _OfflineBanner extends StatelessWidget {
+  const _OfflineBanner({required this.status});
+
+  final OfflineStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    final (title, message, icon) = switch (status) {
+      OfflineStatus.offline => (
+        'Offline mode',
+        'FarmCtl is showing the last known readings until the connection returns.',
+        Icons.cloud_off,
+      ),
+      OfflineStatus.degraded => (
+        'Connectivity issues',
+        'Some thermostats are unreachable and recent values may be stale.',
+        Icons.cloud_queue,
+      ),
+      _ => (
+        'Connectivity notice',
+        'Network status is unavailable.',
+        Icons.cloud_queue,
+      ),
+    };
+
+    return Semantics(
+      container: true,
+      label: title,
+      value: message,
+      child: Card(
+        color: colorScheme.surfaceContainerHighest,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(icon, color: colorScheme.primary),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      message,
+                      style: textTheme.bodyMedium?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/app/lib/features/thermostats/widgets/thermostat_card.dart
+++ b/app/lib/features/thermostats/widgets/thermostat_card.dart
@@ -135,134 +135,133 @@ class ThermostatCard extends StatelessWidget {
           '${thermostat.maxC.toStringAsFixed(1)} degrees Celsius.',
     ].join(' ');
 
-    return MergeSemantics(
-      child: Semantics(
-        container: true,
-        label: 'Thermostat ${thermostat.name}',
-        value: semanticsValue,
-        hint: onTap != null ? 'Tap to view details.' : null,
-        child: Card(
-          clipBehavior: Clip.antiAlias,
-          child: InkWell(
-            onTap: onTap,
-            child: Padding(
-              padding: const EdgeInsets.all(20),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(thermostat.name, style: textTheme.titleLarge),
-                            const SizedBox(height: 6),
-                            Text(
-                              thermostat.rawUrl,
-                              style: textTheme.bodyMedium?.copyWith(
-                                color: colorScheme.onSurfaceVariant,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      if (onRefresh != null)
-                        IconButton(
-                          onPressed: onRefresh,
-                          tooltip: 'Refresh',
-                          icon: const Icon(Icons.refresh),
-                        ),
-                      if (onEdit != null || onDelete != null)
-                        PopupMenuButton<_ThermostatMenuAction>(
-                          onSelected: (value) {
-                            switch (value) {
-                              case _ThermostatMenuAction.edit:
-                                onEdit?.call();
-                                break;
-                              case _ThermostatMenuAction.delete:
-                                onDelete?.call();
-                                break;
-                            }
-                          },
-                          itemBuilder: (context) => [
-                            if (onEdit != null)
-                              const PopupMenuItem(
-                                value: _ThermostatMenuAction.edit,
-                                child: Text('Edit'),
-                              ),
-                            if (onDelete != null)
-                              const PopupMenuItem(
-                                value: _ThermostatMenuAction.delete,
-                                child: Text('Delete'),
-                              ),
-                          ],
-                        ),
-                    ],
-                  ),
-                  const SizedBox(height: 20),
-                  DecoratedBox(
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(16),
-                      gradient: LinearGradient(
-                        colors: [
-                          colorScheme.primaryContainer.withValues(alpha: 0.65),
-                          colorScheme.surfaceContainerHighest.withValues(
-                            alpha: 0.85,
-                          ),
-                        ],
-                        begin: Alignment.topLeft,
-                        end: Alignment.bottomRight,
-                      ),
-                    ),
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 28),
+    return Semantics(
+      container: true,
+      button: onTap != null,
+      label: 'Thermostat ${thermostat.name}',
+      value: semanticsValue,
+      hint: onTap != null ? 'Tap to view details.' : null,
+      child: Card(
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
                       child: Column(
-                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
+                          Text(thermostat.name, style: textTheme.titleLarge),
+                          const SizedBox(height: 6),
                           Text(
-                            temperatureLabel,
-                            style: textTheme.displaySmall?.copyWith(
-                              fontWeight: FontWeight.w600,
-                              color: colorScheme.onPrimaryContainer,
-                            ),
-                          ),
-                          const SizedBox(height: 8),
-                          Text(
-                            supportingLabel,
+                            thermostat.rawUrl,
                             style: textTheme.bodyMedium?.copyWith(
-                              color: colorScheme.onPrimaryContainer.withValues(
-                                alpha: 0.8,
-                              ),
+                              color: colorScheme.onSurfaceVariant,
                             ),
                           ),
                         ],
                       ),
                     ),
-                  ),
-                  const SizedBox(height: 20),
-                  Row(
-                    children: [
-                      Icon(Icons.thermostat, color: colorScheme.primary),
-                      const SizedBox(width: 12),
-                      Text(
-                        '${thermostat.minC.toStringAsFixed(1)}°C – ${thermostat.maxC.toStringAsFixed(1)}°C',
-                        style: textTheme.titleMedium,
+                    if (onRefresh != null)
+                      IconButton(
+                        onPressed: onRefresh,
+                        tooltip: 'Refresh',
+                        icon: const Icon(Icons.refresh),
                       ),
-                      const SizedBox(width: 8),
-                      Text(
-                        'Target range',
-                        style: textTheme.bodyMedium?.copyWith(
-                          color: colorScheme.onSurfaceVariant,
+                    if (onEdit != null || onDelete != null)
+                      PopupMenuButton<_ThermostatMenuAction>(
+                        onSelected: (value) {
+                          switch (value) {
+                            case _ThermostatMenuAction.edit:
+                              onEdit?.call();
+                              break;
+                            case _ThermostatMenuAction.delete:
+                              onDelete?.call();
+                              break;
+                          }
+                        },
+                        itemBuilder: (context) => [
+                          if (onEdit != null)
+                            const PopupMenuItem(
+                              value: _ThermostatMenuAction.edit,
+                              child: Text('Edit'),
+                            ),
+                          if (onDelete != null)
+                            const PopupMenuItem(
+                              value: _ThermostatMenuAction.delete,
+                              child: Text('Delete'),
+                            ),
+                        ],
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 20),
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(16),
+                    gradient: LinearGradient(
+                      colors: [
+                        colorScheme.primaryContainer.withValues(alpha: 0.65),
+                        colorScheme.surfaceContainerHighest.withValues(
+                          alpha: 0.85,
                         ),
-                      ),
-                    ],
+                      ],
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                    ),
                   ),
-                  const SizedBox(height: 12),
-                  _LastSeenStatus(presentation: statusPresentation),
-                ],
-              ),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 28),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          temperatureLabel,
+                          style: textTheme.displaySmall?.copyWith(
+                            fontWeight: FontWeight.w600,
+                            color: colorScheme.onPrimaryContainer,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          supportingLabel,
+                          style: textTheme.bodyMedium?.copyWith(
+                            color: colorScheme.onPrimaryContainer.withValues(
+                              alpha: 0.8,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 20),
+                Row(
+                  children: [
+                    Icon(Icons.thermostat, color: colorScheme.primary),
+                    const SizedBox(width: 12),
+                    Text(
+                      '${thermostat.minC.toStringAsFixed(1)}°C – ${thermostat.maxC.toStringAsFixed(1)}°C',
+                      style: textTheme.titleMedium,
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      'Target range',
+                      style: textTheme.bodyMedium?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                _LastSeenStatus(presentation: statusPresentation),
+              ],
             ),
           ),
         ),

--- a/app/lib/features/thermostats/widgets/thermostat_card.dart
+++ b/app/lib/features/thermostats/widgets/thermostat_card.dart
@@ -2,6 +2,98 @@ import 'package:flutter/material.dart';
 
 import '../models/thermostat_state.dart';
 
+class _StatusPresentation {
+  const _StatusPresentation({required this.text, required this.isError});
+
+  final String text;
+  final bool isError;
+}
+
+_StatusPresentation _describeStatus(ThermostatState? state) {
+  if (state == null || state.lastFetchedAt == null) {
+    return const _StatusPresentation(
+      text: 'No successful readings yet.',
+      isError: false,
+    );
+  }
+
+  final fetchedAt = state.lastFetchedAt!;
+  final value = state.lastValueC;
+  final status = state.status;
+  final message = state.statusMessage;
+  final now = DateTime.now().toUtc();
+  final difference = now.difference(fetchedAt);
+  final relative = _formatRelativeDuration(difference);
+
+  switch (status) {
+    case ThermostatReadingStatus.ok:
+      final base = value != null
+          ? '${value.toStringAsFixed(2)}°C • Updated $relative'
+          : 'Updated $relative';
+      final text = message != null ? '$message • Updated $relative' : base;
+      return _StatusPresentation(text: text, isError: false);
+    case ThermostatReadingStatus.networkError:
+      final base = message ?? 'Last attempt failed: network error';
+      return _StatusPresentation(
+        text: '$base • Checked $relative',
+        isError: true,
+      );
+    case ThermostatReadingStatus.outOfRange:
+      final base = message ?? 'Temperature outside configured range';
+      final text = value != null
+          ? '$base (${value.toStringAsFixed(2)}°C) • Updated $relative'
+          : '$base • Updated $relative';
+      return _StatusPresentation(text: text, isError: true);
+    case ThermostatReadingStatus.httpError:
+      final base = message ?? 'Last attempt failed: server error';
+      return _StatusPresentation(
+        text: '$base • Checked $relative',
+        isError: true,
+      );
+    case ThermostatReadingStatus.parseError:
+      final base = message ?? 'Last attempt failed: invalid payload';
+      return _StatusPresentation(
+        text: '$base • Checked $relative',
+        isError: true,
+      );
+    case ThermostatReadingStatus.unknown:
+      final text = message != null
+          ? '$message • Checked $relative'
+          : 'Last seen $relative';
+      return _StatusPresentation(text: text, isError: true);
+  }
+}
+
+String _formatRelativeDuration(Duration difference) {
+  final seconds = difference.inSeconds.abs();
+  if (seconds < 60) {
+    return 'just now';
+  }
+  final minutes = difference.inMinutes;
+  if (minutes.abs() < 60) {
+    final value = minutes.abs();
+    final unit = value == 1 ? 'min' : 'mins';
+    return '$value $unit ago';
+  }
+  final hours = difference.inHours;
+  if (hours.abs() < 24) {
+    final value = hours.abs();
+    final unit = value == 1 ? 'hour' : 'hours';
+    return '$value $unit ago';
+  }
+  final days = difference.inDays;
+  final unit = days.abs() == 1 ? 'day' : 'days';
+  return '${days.abs()} $unit ago';
+}
+
+String _normalizeForSemantics(String input) {
+  return input
+      .replaceAll('°C', ' degrees Celsius')
+      .replaceAll('•', '.')
+      .replaceAll('  ', ' ')
+      .trim();
+}
+
 class ThermostatCard extends StatelessWidget {
   const ThermostatCard({
     required this.summary,
@@ -34,127 +126,144 @@ class ThermostatCard extends StatelessWidget {
         ? 'Current temperature'
         : 'Awaiting first reading';
 
-    return Card(
-      clipBehavior: Clip.antiAlias,
-      child: InkWell(
-        onTap: onTap,
-        child: Padding(
-          padding: const EdgeInsets.all(20),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
+    final statusPresentation = _describeStatus(state);
+    final semanticsValue = [
+      if (hasTemperature)
+        'Current ${_normalizeForSemantics(temperatureLabel)}.',
+      _normalizeForSemantics(statusPresentation.text),
+      'Target range ${thermostat.minC.toStringAsFixed(1)} to '
+          '${thermostat.maxC.toStringAsFixed(1)} degrees Celsius.',
+    ].join(' ');
+
+    return MergeSemantics(
+      child: Semantics(
+        container: true,
+        label: 'Thermostat ${thermostat.name}',
+        value: semanticsValue,
+        hint: onTap != null ? 'Tap to view details.' : null,
+        child: Card(
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            onTap: onTap,
+            child: Padding(
+              padding: const EdgeInsets.all(20),
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(thermostat.name, style: textTheme.titleLarge),
-                        const SizedBox(height: 6),
-                        Text(
-                          thermostat.rawUrl,
-                          style: textTheme.bodyMedium?.copyWith(
-                            color: colorScheme.onSurfaceVariant,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  if (onRefresh != null)
-                    IconButton(
-                      onPressed: onRefresh,
-                      tooltip: 'Refresh',
-                      icon: const Icon(Icons.refresh),
-                    ),
-                  if (onEdit != null || onDelete != null)
-                    PopupMenuButton<_ThermostatMenuAction>(
-                      onSelected: (value) {
-                        switch (value) {
-                          case _ThermostatMenuAction.edit:
-                            onEdit?.call();
-                            break;
-                          case _ThermostatMenuAction.delete:
-                            onDelete?.call();
-                            break;
-                        }
-                      },
-                      itemBuilder: (context) => [
-                        if (onEdit != null)
-                          const PopupMenuItem(
-                            value: _ThermostatMenuAction.edit,
-                            child: Text('Edit'),
-                          ),
-                        if (onDelete != null)
-                          const PopupMenuItem(
-                            value: _ThermostatMenuAction.delete,
-                            child: Text('Delete'),
-                          ),
-                      ],
-                    ),
-                ],
-              ),
-              const SizedBox(height: 20),
-              DecoratedBox(
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(16),
-                  gradient: LinearGradient(
-                    colors: [
-                      colorScheme.primaryContainer.withValues(alpha: 0.65),
-                      colorScheme.surfaceContainerHighest.withValues(
-                        alpha: 0.85,
-                      ),
-                    ],
-                    begin: Alignment.topLeft,
-                    end: Alignment.bottomRight,
-                  ),
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 28),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        temperatureLabel,
-                        style: textTheme.displaySmall?.copyWith(
-                          fontWeight: FontWeight.w600,
-                          color: colorScheme.onPrimaryContainer,
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(thermostat.name, style: textTheme.titleLarge),
+                            const SizedBox(height: 6),
+                            Text(
+                              thermostat.rawUrl,
+                              style: textTheme.bodyMedium?.copyWith(
+                                color: colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                          ],
                         ),
                       ),
-                      const SizedBox(height: 8),
-                      Text(
-                        supportingLabel,
-                        style: textTheme.bodyMedium?.copyWith(
-                          color: colorScheme.onPrimaryContainer.withValues(
-                            alpha: 0.8,
+                      if (onRefresh != null)
+                        IconButton(
+                          onPressed: onRefresh,
+                          tooltip: 'Refresh',
+                          icon: const Icon(Icons.refresh),
+                        ),
+                      if (onEdit != null || onDelete != null)
+                        PopupMenuButton<_ThermostatMenuAction>(
+                          onSelected: (value) {
+                            switch (value) {
+                              case _ThermostatMenuAction.edit:
+                                onEdit?.call();
+                                break;
+                              case _ThermostatMenuAction.delete:
+                                onDelete?.call();
+                                break;
+                            }
+                          },
+                          itemBuilder: (context) => [
+                            if (onEdit != null)
+                              const PopupMenuItem(
+                                value: _ThermostatMenuAction.edit,
+                                child: Text('Edit'),
+                              ),
+                            if (onDelete != null)
+                              const PopupMenuItem(
+                                value: _ThermostatMenuAction.delete,
+                                child: Text('Delete'),
+                              ),
+                          ],
+                        ),
+                    ],
+                  ),
+                  const SizedBox(height: 20),
+                  DecoratedBox(
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(16),
+                      gradient: LinearGradient(
+                        colors: [
+                          colorScheme.primaryContainer.withValues(alpha: 0.65),
+                          colorScheme.surfaceContainerHighest.withValues(
+                            alpha: 0.85,
                           ),
+                        ],
+                        begin: Alignment.topLeft,
+                        end: Alignment.bottomRight,
+                      ),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 28),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            temperatureLabel,
+                            style: textTheme.displaySmall?.copyWith(
+                              fontWeight: FontWeight.w600,
+                              color: colorScheme.onPrimaryContainer,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            supportingLabel,
+                            style: textTheme.bodyMedium?.copyWith(
+                              color: colorScheme.onPrimaryContainer.withValues(
+                                alpha: 0.8,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 20),
+                  Row(
+                    children: [
+                      Icon(Icons.thermostat, color: colorScheme.primary),
+                      const SizedBox(width: 12),
+                      Text(
+                        '${thermostat.minC.toStringAsFixed(1)}°C – ${thermostat.maxC.toStringAsFixed(1)}°C',
+                        style: textTheme.titleMedium,
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        'Target range',
+                        style: textTheme.bodyMedium?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
                         ),
                       ),
                     ],
                   ),
-                ),
-              ),
-              const SizedBox(height: 20),
-              Row(
-                children: [
-                  Icon(Icons.thermostat, color: colorScheme.primary),
-                  const SizedBox(width: 12),
-                  Text(
-                    '${thermostat.minC.toStringAsFixed(1)}°C – ${thermostat.maxC.toStringAsFixed(1)}°C',
-                    style: textTheme.titleMedium,
-                  ),
-                  const SizedBox(width: 8),
-                  Text(
-                    'Target range',
-                    style: textTheme.bodyMedium?.copyWith(
-                      color: colorScheme.onSurfaceVariant,
-                    ),
-                  ),
+                  const SizedBox(height: 12),
+                  _LastSeenStatus(presentation: statusPresentation),
                 ],
               ),
-              const SizedBox(height: 12),
-              _LastSeenStatus(state: state),
-            ],
+            ),
           ),
         ),
       ),
@@ -165,98 +274,22 @@ class ThermostatCard extends StatelessWidget {
 enum _ThermostatMenuAction { edit, delete }
 
 class _LastSeenStatus extends StatelessWidget {
-  const _LastSeenStatus({this.state});
+  const _LastSeenStatus({required this.presentation});
 
-  final ThermostatState? state;
+  final _StatusPresentation presentation;
 
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
     final colorScheme = Theme.of(context).colorScheme;
 
-    if (state == null || state!.lastFetchedAt == null) {
-      return Text(
-        'No successful readings yet.',
-        style: textTheme.bodyMedium?.copyWith(
-          color: colorScheme.onSurfaceVariant,
-        ),
-      );
-    }
-
-    final fetchedAt = state!.lastFetchedAt!;
-    final value = state!.lastValueC;
-    final status = state!.status;
-    final message = state!.statusMessage;
-    final now = DateTime.now().toUtc();
-    final difference = now.difference(fetchedAt);
-    final relative = _formatRelativeDuration(difference);
-
-    String statusText;
-    var isError = false;
-    switch (status) {
-      case ThermostatReadingStatus.ok:
-        final base = value != null
-            ? '${value.toStringAsFixed(2)}°C • Updated $relative'
-            : 'Updated $relative';
-        statusText = message != null ? '$message • Updated $relative' : base;
-        break;
-      case ThermostatReadingStatus.networkError:
-        final base = message ?? 'Last attempt failed: network error';
-        statusText = '$base • Checked $relative';
-        isError = true;
-        break;
-      case ThermostatReadingStatus.outOfRange:
-        final base = message ?? 'Temperature outside configured range';
-        statusText = value != null
-            ? '$base (${value.toStringAsFixed(2)}°C) • Updated $relative'
-            : '$base • Updated $relative';
-        isError = true;
-        break;
-      case ThermostatReadingStatus.httpError:
-        final base = message ?? 'Last attempt failed: server error';
-        statusText = '$base • Checked $relative';
-        isError = true;
-        break;
-      case ThermostatReadingStatus.parseError:
-        final base = message ?? 'Last attempt failed: invalid payload';
-        statusText = '$base • Checked $relative';
-        isError = true;
-        break;
-      case ThermostatReadingStatus.unknown:
-        statusText = message != null
-            ? '$message • Checked $relative'
-            : 'Last seen $relative';
-        isError = true;
-        break;
-    }
-
     return Text(
-      statusText,
+      presentation.text,
       style: textTheme.bodyMedium?.copyWith(
-        color: isError ? colorScheme.error : colorScheme.onSurfaceVariant,
+        color: presentation.isError
+            ? colorScheme.error
+            : colorScheme.onSurfaceVariant,
       ),
     );
-  }
-
-  String _formatRelativeDuration(Duration difference) {
-    final seconds = difference.inSeconds.abs();
-    if (seconds < 60) {
-      return 'just now';
-    }
-    final minutes = difference.inMinutes;
-    if (minutes.abs() < 60) {
-      final value = minutes.abs();
-      final unit = value == 1 ? 'min' : 'mins';
-      return '$value $unit ago';
-    }
-    final hours = difference.inHours;
-    if (hours.abs() < 24) {
-      final value = hours.abs();
-      final unit = value == 1 ? 'hour' : 'hours';
-      return '$value $unit ago';
-    }
-    final days = difference.inDays;
-    final unit = days.abs() == 1 ? 'day' : 'days';
-    return '${days.abs()} $unit ago';
   }
 }

--- a/app/lib/features/thermostats/widgets/thermostat_history_chart.dart
+++ b/app/lib/features/thermostats/widgets/thermostat_history_chart.dart
@@ -57,89 +57,103 @@ class ThermostatHistoryChart extends StatelessWidget {
     final maxX = spots.last.x;
     final interval = _suggestedInterval(maxX - minX);
 
-    return SizedBox(
-      height: 240,
-      child: LineChart(
-        LineChartData(
-          minX: minX,
-          maxX: maxX == minX ? maxX + 1 : maxX,
-          minY: minY - padding,
-          maxY: maxY + padding,
-          clipData: const FlClipData.all(),
-          titlesData: FlTitlesData(
-            topTitles: const AxisTitles(
-              sideTitles: SideTitles(showTitles: false),
-            ),
-            rightTitles: const AxisTitles(
-              sideTitles: SideTitles(showTitles: false),
-            ),
-            leftTitles: AxisTitles(
-              sideTitles: SideTitles(
-                showTitles: true,
-                reservedSize: 48,
-                interval: _suggestedYInterval(minY, maxY),
-                getTitlesWidget: (value, meta) => Text(
-                  value.toStringAsFixed(2),
-                  style: Theme.of(context).textTheme.bodySmall,
+    final semanticsFormatter = DateFormat.yMMMd().add_Hm();
+    final semanticsValue =
+        'From ${semanticsFormatter.format(sorted.first.observedAt.toLocal())} '
+        'to ${semanticsFormatter.format(sorted.last.observedAt.toLocal())}. '
+        'Temperatures ranged from ${minY.toStringAsFixed(1)} to '
+        '${maxY.toStringAsFixed(1)} degrees Celsius.';
+
+    return Semantics(
+      container: true,
+      label: 'Temperature history for ${range.label}',
+      value: semanticsValue,
+      child: SizedBox(
+        height: 240,
+        child: LineChart(
+          LineChartData(
+            minX: minX,
+            maxX: maxX == minX ? maxX + 1 : maxX,
+            minY: minY - padding,
+            maxY: maxY + padding,
+            clipData: const FlClipData.all(),
+            titlesData: FlTitlesData(
+              topTitles: const AxisTitles(
+                sideTitles: SideTitles(showTitles: false),
+              ),
+              rightTitles: const AxisTitles(
+                sideTitles: SideTitles(showTitles: false),
+              ),
+              leftTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  reservedSize: 48,
+                  interval: _suggestedYInterval(minY, maxY),
+                  getTitlesWidget: (value, meta) => Text(
+                    value.toStringAsFixed(2),
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                ),
+              ),
+              bottomTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  interval: interval,
+                  reservedSize: 36,
+                  getTitlesWidget: (value, meta) {
+                    final date = base.add(Duration(seconds: value.toInt()));
+                    final formatter = _formatterForRange(range);
+                    return Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Text(
+                        formatter.format(date.toLocal()),
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                    );
+                  },
                 ),
               ),
             ),
-            bottomTitles: AxisTitles(
-              sideTitles: SideTitles(
-                showTitles: true,
-                interval: interval,
-                reservedSize: 36,
-                getTitlesWidget: (value, meta) {
-                  final date = base.add(Duration(seconds: value.toInt()));
-                  final formatter = _formatterForRange(range);
-                  return Padding(
-                    padding: const EdgeInsets.only(top: 4),
-                    child: Text(
-                      formatter.format(date.toLocal()),
-                      style: Theme.of(context).textTheme.bodySmall,
-                    ),
-                  );
+            gridData: FlGridData(
+              show: true,
+              drawVerticalLine: false,
+              horizontalInterval: _suggestedYInterval(minY, maxY),
+            ),
+            lineTouchData: LineTouchData(
+              touchTooltipData: LineTouchTooltipData(
+                getTooltipColor: (_) =>
+                    Theme.of(context).colorScheme.surfaceContainerHighest,
+                getTooltipItems: (touchedSpots) {
+                  final formatter = _detailedFormatterForRange(range);
+                  return touchedSpots.map((spot) {
+                    final timestamp = base.add(
+                      Duration(seconds: spot.x.toInt()),
+                    );
+                    return LineTooltipItem(
+                      '${spot.y.toStringAsFixed(2)}°C\n${formatter.format(timestamp.toLocal())}',
+                      Theme.of(context).textTheme.bodyMedium!,
+                    );
+                  }).toList();
                 },
               ),
             ),
-          ),
-          gridData: FlGridData(
-            show: true,
-            drawVerticalLine: false,
-            horizontalInterval: _suggestedYInterval(minY, maxY),
-          ),
-          lineTouchData: LineTouchData(
-            touchTooltipData: LineTouchTooltipData(
-              getTooltipColor: (_) =>
-                  Theme.of(context).colorScheme.surfaceContainerHighest,
-              getTooltipItems: (touchedSpots) {
-                final formatter = _detailedFormatterForRange(range);
-                return touchedSpots.map((spot) {
-                  final timestamp = base.add(Duration(seconds: spot.x.toInt()));
-                  return LineTooltipItem(
-                    '${spot.y.toStringAsFixed(2)}°C\n${formatter.format(timestamp.toLocal())}',
-                    Theme.of(context).textTheme.bodyMedium!,
-                  );
-                }).toList();
-              },
-            ),
-          ),
-          lineBarsData: [
-            for (final seg in segmentedSpots)
-              LineChartBarData(
-                spots: seg,
-                isCurved: false,
-                barWidth: 3,
-                color: Theme.of(context).colorScheme.primary,
-                belowBarData: BarAreaData(
-                  show: true,
-                  color: Theme.of(
-                    context,
-                  ).colorScheme.primary.withValues(alpha: 0.12),
+            lineBarsData: [
+              for (final seg in segmentedSpots)
+                LineChartBarData(
+                  spots: seg,
+                  isCurved: false,
+                  barWidth: 3,
+                  color: Theme.of(context).colorScheme.primary,
+                  belowBarData: BarAreaData(
+                    show: true,
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.primary.withValues(alpha: 0.12),
+                  ),
+                  dotData: const FlDotData(show: false),
                 ),
-                dotData: const FlDotData(show: false),
-              ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   flutter_riverpod: ^3.0.3
   go_router: ^16.2.4
   freezed_annotation: ^3.1.0

--- a/app/test/unit/offline_status_provider_test.dart
+++ b/app/test/unit/offline_status_provider_test.dart
@@ -1,0 +1,157 @@
+import 'dart:async';
+
+import 'package:farmctl/features/thermostats/models/thermostat.dart';
+import 'package:farmctl/features/thermostats/models/thermostat_state.dart';
+import 'package:farmctl/features/thermostats/providers/thermostat_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Thermostat createThermostat(String id) {
+    final now = DateTime.utc(2025, 10, 20);
+    return Thermostat(
+      id: id,
+      name: 'Thermostat $id',
+      rawUrl: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      minC: 2,
+      maxC: 8,
+      hysteresisEnabled: false,
+      monitoringEnabled: true,
+      createdAt: now,
+      updatedAt: now,
+    );
+  }
+
+  ThermostatState createState({
+    required String thermostatId,
+    required ThermostatReadingStatus status,
+    DateTime? lastFetchedAt,
+  }) {
+    final now = DateTime.utc(2025, 10, 20, 12);
+    return ThermostatState(
+      thermostatId: thermostatId,
+      status: status,
+      lastValueC: status == ThermostatReadingStatus.ok ? 5.5 : null,
+      lastFetchedAt: lastFetchedAt,
+      etag: null,
+      statusMessage: null,
+      lastAlarmAt: null,
+      snoozedUntil: null,
+      silenceUntilOk: false,
+      createdAt: now,
+      updatedAt: now,
+    );
+  }
+
+  Future<OfflineStatus> readStatus(ProviderContainer container) async {
+    final completer = Completer<OfflineStatus>();
+    final sub = container.listen<OfflineStatus>(offlineStatusProvider, (
+      previous,
+      next,
+    ) {
+      if (!completer.isCompleted && next != OfflineStatus.unknown) {
+        completer.complete(next);
+      }
+    }, fireImmediately: true);
+
+    try {
+      return await completer.future.timeout(
+        const Duration(seconds: 1),
+        onTimeout: () => container.read(offlineStatusProvider),
+      );
+    } finally {
+      sub.close();
+    }
+  }
+
+  test(
+    'offlineStatusProvider reports offline when only network errors',
+    () async {
+      final container = ProviderContainer(
+        overrides: [
+          thermostatsProvider.overrideWith(
+            (ref) => Stream.value([
+              ThermostatSummary(
+                thermostat: createThermostat('1'),
+                state: createState(
+                  thermostatId: '1',
+                  status: ThermostatReadingStatus.networkError,
+                  lastFetchedAt: DateTime.utc(2025, 10, 20, 11, 55),
+                ),
+              ),
+            ]),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final status = await readStatus(container);
+      expect(status, OfflineStatus.offline);
+    },
+  );
+
+  test('offlineStatusProvider reports degraded when mixed results', () async {
+    final container = ProviderContainer(
+      overrides: [
+        thermostatsProvider.overrideWith(
+          (ref) => Stream.value([
+            ThermostatSummary(
+              thermostat: createThermostat('1'),
+              state: createState(
+                thermostatId: '1',
+                status: ThermostatReadingStatus.networkError,
+                lastFetchedAt: DateTime.utc(2025, 10, 20, 11, 55),
+              ),
+            ),
+            ThermostatSummary(
+              thermostat: createThermostat('2'),
+              state: createState(
+                thermostatId: '2',
+                status: ThermostatReadingStatus.ok,
+                lastFetchedAt: DateTime.utc(2025, 10, 20, 11, 58),
+              ),
+            ),
+          ]),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final status = await readStatus(container);
+    expect(status, OfflineStatus.degraded);
+  });
+
+  test(
+    'offlineStatusProvider reports online when no network failures',
+    () async {
+      final container = ProviderContainer(
+        overrides: [
+          thermostatsProvider.overrideWith(
+            (ref) => Stream.value([
+              ThermostatSummary(
+                thermostat: createThermostat('1'),
+                state: createState(
+                  thermostatId: '1',
+                  status: ThermostatReadingStatus.ok,
+                  lastFetchedAt: DateTime.utc(2025, 10, 20, 11, 55),
+                ),
+              ),
+              ThermostatSummary(
+                thermostat: createThermostat('2'),
+                state: createState(
+                  thermostatId: '2',
+                  status: ThermostatReadingStatus.outOfRange,
+                  lastFetchedAt: DateTime.utc(2025, 10, 20, 11, 54),
+                ),
+              ),
+            ]),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final status = await readStatus(container);
+      expect(status, OfflineStatus.online);
+    },
+  );
+}

--- a/app/test/unit/thermostat_repository_test.dart
+++ b/app/test/unit/thermostat_repository_test.dart
@@ -201,6 +201,73 @@ void main() {
     },
   );
 
+  test(
+    'pruneRetention removes stale readings and caps total entries',
+    () async {
+      final thermostat = await repository.create(
+        ThermostatDraft(
+          name: 'Storage',
+          rawUrl: '11111111111111111111111111111111',
+          minC: 2,
+          maxC: 10,
+        ),
+      );
+
+      final now = DateTime.utc(2025, 10, 20, 12);
+      final samples = <TemperatureSample>[];
+
+      for (var i = 0; i < 12; i++) {
+        samples.add(
+          TemperatureSample.revision(
+            thermostatId: thermostat.id,
+            revisionId: 'old_$i',
+            valueC: 4.0 + i,
+            observedAt: now.subtract(Duration(days: 600 + i)),
+          ),
+        );
+      }
+
+      for (var i = 0; i < 5200; i++) {
+        samples.add(
+          TemperatureSample.revision(
+            thermostatId: thermostat.id,
+            revisionId: 'recent_$i',
+            valueC: 6.0,
+            observedAt: now.subtract(Duration(minutes: i)),
+          ),
+        );
+      }
+
+      await repository.upsertHistory(
+        thermostatId: thermostat.id,
+        samples: samples,
+      );
+
+      await repository.pruneRetention(
+        thermostatId: thermostat.id,
+        maxAge: const Duration(days: 365),
+        maxEntriesPerThermostat: 5000,
+        now: now,
+      );
+
+      final remaining = await database.listTemperatureReadings(thermostat.id);
+      expect(remaining.length, 5000);
+      expect(
+        remaining.every((row) => !row.id.contains('old_')),
+        isTrue,
+        reason: 'older revisions should be pruned',
+      );
+      final oldest = remaining
+          .map((row) => row.observedAt)
+          .reduce((a, b) => a.isBefore(b) ? a : b);
+      expect(
+        oldest.isAfter(now.subtract(const Duration(days: 365))),
+        isTrue,
+        reason: 'readings older than retention window should be removed',
+      );
+    },
+  );
+
   test('replaceHistory stores samples and sorts ascending', () async {
     final thermostat = await repository.create(
       ThermostatDraft(


### PR DESCRIPTION
## Summary
- add an offline status provider with banner UI so connectivity degradation is surfaced to users
- implement database/history retention pruning and invoke it from both foreground history refreshes and the background monitor, with unit coverage
- improve accessibility semantics for thermostat cards and charts, enable localization delegates, and refresh documentation/plan entries for iteration 10

## Testing
- ./tool/setup_flutter.sh
- flutter analyze
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68ee58b90374832593178e4537dc6bfc