### PR TITLE
Bug-hunt #3: UI / charts / settings / alarm-launch fixes

### DIFF
--- a/.agent/bug-hunt-ui-2026-06-27.md
+++ b/.agent/bug-hunt-ui-2026-06-27.md
@@ -1,0 +1,208 @@
+# FarmCtl UI / Charts / Settings / Routing Bug-Hunt Report
+
+**Date:** 2026-06-27
+**Scope:** UI / chart / settings / routing / lifecycle code (v0.3.0, post-remediation). The data /
+concurrency / networking / parsing layers (`thermostat_monitor`, `thermostat_repository`,
+`thermostat_database`, `thermostat_client`, `temperature_parser`, `alert_config_repository`) were
+covered by a prior merged hunt and were intentionally excluded.
+**Method:** Read-only static analysis of the target files. Each candidate was independently re-read
+against the live source, then run through a refute-by-default verifier that discarded false positives,
+corrected over-stated mechanisms, and re-rated severity. Only bugs that survived verification are
+listed as confirmed. Dismissed candidates are recorded in the appendix with one-line reasons.
+
+---
+
+## Executive Summary
+
+Seven correctness bugs were confirmed across the alarm-launch path, the alarm navigation stack, the
+edit-thermostat state path, the history chart's timestamp math, and two Settings-page handlers. No
+critical (data-loss / guaranteed missed-or-false-alarm / crash) bugs were found in this layer. The two
+highest-impact issues both concern the cold-launch / re-tap alarm acknowledgement flow, where tapping an
+alarm notification can fail to open the in-app alarm screen (cold launch) or can stack duplicate alarm
+screens with a premature wakelock release (re-tap). The chart downsampler systematically mis-positions the
+trailing (most-recent) point in time on every multi-sample chart. The remaining issues are state-desync /
+resource-hygiene / swallowed-error defects of low impact.
+
+### Counts
+
+| Severity | Count |
+|----------|-------|
+| Critical | 0 |
+| High     | 2 |
+| Medium   | 2 |
+| Low      | 3 |
+| Dismissed | 4 |
+
+---
+
+## Confirmed Bugs
+
+### HIGH
+
+#### UI-01 — Alarm notification tap from a cold-killed app never opens the in-app alarm screen
+- **File:** `app/lib/core/background/thermostat_monitor.dart:186-217, 743-808`
+- **What:** The tap handler `_handleNotificationResponse` is wired only through
+  `onDidReceiveNotificationResponse` in `_initializeNotifications`. In flutter_local_notifications that
+  callback fires only while the Dart isolate is alive. A tap that *launches* the app from a terminated
+  state is delivered only via `getNotificationAppLaunchDetails()` / `didNotificationLaunchApp`, which is
+  never called anywhere in the repo (grep returns nothing). `main()` runs `initializeBackgroundMonitoring()`
+  then `runApp` with no launch-detail query, the router's `initialLocation` is `/thermostats`, and
+  `AndroidManifest.xml` gives MainActivity only a MAIN/LAUNCHER intent-filter (no deep link). So on a cold
+  launch the body tap lands on `/thermostats` and the in-app `/alarm` acknowledgement screen never appears.
+  The `_navigateToAlarm` 60-attempt retry loop — whose own comment cites "cold launch from a notification
+  tap" — is dead code for that stated purpose because nothing reads the launch details to invoke it.
+- **Trigger:** Phone sits overnight; OS kills the FarmCtl process. A thermostat goes out of range and the
+  ongoing alarm notification is posted by the WorkManager background isolate. User taps it → app
+  cold-launches to `/thermostats`, no alarm screen, no in-app path to acknowledge/snooze.
+- **Fix:** In `main()` (or app bootstrap) after the plugin is initialized, call
+  `FlutterLocalNotificationsPlugin().getNotificationAppLaunchDetails()`; if
+  `didNotificationLaunchApp == true`, extract the stored `notificationResponse.payload` (thermostatId) and
+  route to `AlarmRoute.pathFor(thermostatId)` once the router is ready (reusing the existing
+  `_navigateToAlarm` retry machinery). Also register `onDidReceiveBackgroundNotificationResponse` so action
+  buttons work from the background/terminated state.
+
+#### UI-02 — Re-tapping a re-posted alarm notification stacks a duplicate AlarmFullScreenPage and drops the wakelock early
+- **File:** `app/lib/core/background/thermostat_monitor.dart:786-808` (with
+  `app/lib/features/thermostats/view/alarm_fullscreen_page.dart:31-34`)
+- **Severity:** verifier adjusted high → **medium** (edge-case interaction path; no data loss / missed
+  alarm). Reported under HIGH per the original candidate severity, but treat as medium impact.
+- **What:** `_navigateToAlarm` unconditionally calls
+  `GoRouter.of(context).push(AlarmRoute.pathFor(thermostatId))`. go_router's imperative `push` assigns a
+  unique page key and does NOT deduplicate by location, so it stacks a second `AlarmFullScreenPage` for the
+  same id. The alarm notification is `ongoing: true` / `autoCancel: false` and is re-posted each monitoring
+  cycle while the reading stays out of range. Tapping the re-posted notification while alarm page A is still
+  on top pushes page B atop A. Dismissing/snoozing B pops only B, leaving identical page A underneath (user
+  believes they acknowledged). Worse, each `_AlarmFullScreenPageState.dispose()` calls
+  `WakelockPlus.disable()`, so popping B disables the wakelock while page A is still mounted and visible.
+- **Trigger:** Open alarm via notification tap (page A). Reading stays out of range → notification re-posted
+  next cycle. Tap it again → page B pushed atop A. Dismiss B → page A still visible; wakelock disabled while
+  an alarm screen is still on screen.
+- **Fix:** Before pushing, check whether the current GoRouter location is already
+  `AlarmRoute.pathFor(thermostatId)` (e.g. via `GoRouterState.of(context).matchedLocation` /
+  `GoRouter.of(context).routerDelegate.currentConfiguration`); if so, skip the push (or `go` instead of
+  `push` to replace). Alternatively add a router redirect that collapses duplicate `/alarm/<id>` entries.
+  Re-enabling the wakelock in `AlarmFullScreenPage.initState` (already the case) combined with dedup avoids
+  the premature-disable problem.
+
+### MEDIUM
+
+#### UI-03 — Aggregated history points are plotted at bucket midpoint, shifting the trailing/partial bucket into the future
+- **File:** `app/lib/features/thermostats/utils/thermostat_history_downsampler.dart:94-101`
+- **What:** Each bucket's representative timestamp is hard-coded to `bucketStart + bucketSeconds ~/ 2`
+  (the bucket center), independent of the actual `observedAt` of the samples it contains. Buckets are
+  anchored to the first sample's time (`first`, line 22), not a calendar boundary, with
+  `bucketStart = first + bucketIndex*bucketSeconds`. A sample lies anywhere in
+  `[bucketStart, bucketStart+bucketSeconds)`, so the plotted point is shifted by up to ±half the bucket
+  width: 2.5 / 5 / 30 / 60 / 60 / 60 min for hour/day/week/month/year/all. For a partially-filled bucket —
+  most importantly the trailing bucket that typically holds one just-arrived reading near `bucketStart` —
+  the synthetic point is drawn up to half a bucket *later* than the reading occurred, and can land after
+  `DateTime.now()`. The chart consumes this `observedAt` for x-position, tooltip timestamps, and bottom-axis
+  labels (`thermostat_history_chart.dart` lines 45, 125, 100), so the visualized "when" is wrong for the
+  newest point on every realistic multi-sample chart. Single-overall-sample charts are unaffected
+  (`downsample` returns early at `length <= 1`).
+- **Trigger:** Open a Week-range chart (60-min buckets). The latest reading arrived ~5 min ago and is the
+  only sample in the trailing bucket; it is rendered ~30 min later (and ~25 min in the future), and the
+  tooltip shows the midpoint time, not the reading's real timestamp.
+- **Fix:** Use a data-driven representative timestamp instead of the bucket center — e.g. the mean (or max)
+  of the contained samples' `observedAt`, or for a single-sample bucket the sample's own `observedAt`. Track
+  the timestamps in `_SampleBucket.add` and compute the representative from them in `toSample`.
+
+#### UI-04 — Editing a thermostat clears an active out-of-range state (transient UI/state desync)
+- **File:** `app/lib/features/thermostats/data/thermostat_service.dart:69-77` (driven by `_editThermostat`
+  in `app/lib/features/thermostats/view/thermostats_page.dart:41-71`)
+- **Severity:** verifier adjusted high → **medium** (alarm pipeline self-corrects on next monitor tick; no
+  actual missed/false alarm).
+- **What:** `updateAndTest` unconditionally writes `status: ThermostatReadingStatus.ok` and message
+  `'Fetched X°C'` after a successful test fetch, with NO out-of-range check against the new min/max — unlike
+  `refresh()` (lines 87-124) which calls `isThermostatReadingOutOfRange` before saving. `_editThermostat`
+  calls `updateAndTest` on every save. So editing a thermostat that is currently `outOfRange` (even just
+  renaming it, or setting a range that still excludes the current value) overwrites the persisted state to
+  `ok`, wiping the out-of-range flag/message. The card (derived from `summary.state.status`) flips from
+  red/out-of-range to green/ok with a misleading "Fetched X°C" until the next monitor cycle re-evaluates.
+  The alarm-firing path itself recovers on the next tick (the rate-limit suppression branch only fires when
+  `previousState.status == outOfRange`, which the edit just cleared, so the alarm re-arms rather than being
+  suppressed), and `silenceUntilOk` / `snoozedUntil` are left untouched — hence medium, not a missed alarm.
+- **Trigger:** A thermostat reads 95°C with range 0-40 (status outOfRange, card red). Open Edit, change only
+  the name (or set range 0-50, still below 95), tap Test & Save. State is overwritten to `ok` /
+  `Fetched 95.00°C`; the card turns green and the out-of-range condition is visually silenced until the
+  background monitor next runs.
+- **Fix:** In `updateAndTest` (and `createAndTest`), evaluate `isThermostatReadingOutOfRange` against the
+  *new* draft's min/max before saving, mirroring `refresh()`: persist `outOfRange` + the formatted message
+  when the fetched value violates the new range, otherwise `ok`.
+
+### LOW
+
+#### UI-05 — `_testGithubToken` has no try/catch: a thrown `loadConfig()` makes "Test token" a silent no-op
+- **File:** `app/lib/features/settings/view/settings_page.dart:442-450`
+- **What:** Unlike every sibling handler in this file (`_setGithubToken` :421-440 and `_exportLogs` :406-419
+  both catch and show a "Failed to…" snackbar), `_testGithubToken` has no error handling. `loadConfig()`
+  does real async I/O (Drift `getAlertConfig()` + secure-storage `_resolveToken()`), both of which can throw
+  — and the codebase itself guards `loadConfig()` with try/catch elsewhere
+  (`thermostat_monitor.dart:178, :270`), confirming it is a known throwing path. `testToken()` wraps its own
+  errors and returns a String, so it is not the throwing path. If `loadConfig()` throws on a transient
+  DB/secure-storage error, the Future completes with an unhandled error, no snackbar fires, and the user gets
+  zero feedback after tapping "Test token". (The candidate's additional web claim was refuted: the file hard-
+  imports `dart:io`, so web is not a buildable target — the synchronous `Platform.environment`
+  `UnsupportedError` never occurs in practice.)
+- **Trigger:** Tap "Test token" while a transient DB/secure-storage read failure occurs → no snackbar, no
+  feedback at all, in contrast to every other button on the page.
+- **Fix:** Wrap the body in try/catch (matching `_setGithubToken`) and show a
+  `'Failed to test GitHub token: $error'` snackbar (guarded by `if (!mounted) return;`).
+
+#### UI-06 — Clear/visibility suffix-icon desyncs from the token field while typing (no listener / no setState)
+- **File:** `app/lib/features/settings/view/settings_page.dart:707-745`
+- **What:** The clear IconButton is conditionally rendered via `if (_tokenController.text.isNotEmpty)`
+  (line 729), but `_tokenController` (created in `initState` line 499) has no `addListener`, and the
+  TextField has no `onChanged` (only `onSubmitted`). Typing schedules no `setState` in the parent state, so
+  `build()` is not re-run per keystroke. The Clear (×) button therefore does not appear when the first
+  character is typed into an empty field, nor disappear when the field is cleared via backspace, until an
+  unrelated rebuild (toggling the obscure eye icon at lines 722-726, or a provider re-emit driving
+  `didUpdateWidget` at lines 503-508). The TextField repaints its own text because it internally listens to
+  the controller; the parent's conditional suffix icon does not. Impact is limited to a missing/stale
+  convenience Clear button — the field, Save token, and onSubmitted all work.
+- **Trigger:** Open Settings with an empty token field, type `g`. The Clear button does not appear until an
+  unrelated rebuild (e.g. tapping the show/hide eye).
+- **Fix:** Add `_tokenController.addListener(() => setState(() {}))` in `initState` (remove it in
+  `dispose`), or give the TextField an `onChanged: (_) => setState(() {})`, so the suffix icon re-evaluates
+  on each keystroke.
+
+#### UI-07 — Per-submit `ThermostatHttpClient` (two Dio instances) is never closed — socket/resource churn on every add/edit
+- **File:** `app/lib/features/thermostats/data/thermostat_service.dart:32-37, 61-66` (invoked from
+  `thermostats_page.dart` `_createThermostat`/`_editThermostat` onSubmit)
+- **What:** When a GitHub token override is present, `createAndTest` and `updateAndTest` each construct a
+  fresh `ThermostatHttpClient(githubToken: tokenOverride, allowAnonFallback: false)`. That constructor builds
+  TWO Dio instances (`_dio` and `_dioNoAuth`, `thermostat_client.dart:34-41`), each owning an HttpClient with
+  persistent connections and a RetryInterceptor. The client is used for one `fetchCurrent` and then dropped
+  with no `close()`/`dispose()` (the class has no such method). Every add/edit while a token is configured
+  allocates two un-closed Dio/HttpClient instances. Impact is short-lived churn rather than an unbounded leak
+  — Dart's default HttpClient closes idle keep-alive sockets after its idleTimeout (~15s) and the Dio objects
+  become GC-able once `network` goes out of scope — but it is still avoidable resource hygiene.
+- **Trigger:** Configure a GitHub token, then repeatedly add/edit thermostats. Each Test & Save allocates a
+  new two-Dio client that is never explicitly closed.
+- **Fix:** Add a `close()`/`dispose()` to `ThermostatHttpClient` (closing both `_dio` and `_dioNoAuth`), and
+  in `createAndTest`/`updateAndTest` call it in a `finally` block when the local override client was created
+  (do not close the shared `_network`).
+
+---
+
+## Appendix: Dismissed Candidates
+
+1. **Exact-alarm switch can stay visually ON after permission denied** —
+   `settings_page.dart`. Refuted: Flutter's `SwitchListTile.adaptive` is a fully *controlled* widget whose
+   thumb is derived purely from the `value` prop on each build. On deny the config never becomes true (early
+   return), so the switch never renders ON in the first place. No displayed-vs-stored desync.
+
+2. **Detail page range selection not updated after changing range in fullscreen chart** —
+   `thermostat_detail_page.dart`. Refuted: each page is internally consistent (its SegmentedButton/dropdown
+   and its chart read the same `_range`). Independent per-page selection is a deliberate design choice, not a
+   widget-vs-data desync — a UX decision, not a logic defect.
+
+3. **Min/Max fields lack form validators** — `thermostat_form_dialog.dart`. Refuted: empty/non-numeric and
+   out-of-range inputs ARE caught and surfaced as field-specific errors within the same synchronous `_submit`
+   (manual parse + `ThermostatValidator.validate`); `autovalidateMode` is disabled so all fields behave
+   identically. No wrong result on any real path; the concern is hypothetical fragility (style/refactor).
+
+4. **Fullscreen history page unconditionally resets orientation to all on dispose** —
+   `thermostat_history_fullscreen_page.dart`. Refuted: there is no app-wide portrait lock anywhere, so
+   restore-to-all on dispose is functionally identical to the platform default. No user-observable wrong
+   behavior today; the only trigger requires first adding a lock that does not exist.

--- a/app/lib/core/background/thermostat_monitor.dart
+++ b/app/lib/core/background/thermostat_monitor.dart
@@ -674,6 +674,9 @@ Future<void> _initializeNotifications(
   await plugin.initialize(
     initializationSettings,
     onDidReceiveNotificationResponse: onDidReceiveNotificationResponse,
+    // Handles action buttons (snooze/silence) pressed while the app is
+    // terminated/background, in a dedicated isolate.
+    onDidReceiveBackgroundNotificationResponse: _handleNotificationResponse,
   );
   final androidPlugin = plugin
       .resolvePlatformSpecificImplementation<
@@ -740,7 +743,39 @@ Future<void> _showMonitoringActiveNotification(
   );
 }
 
+/// Routes a cold-launch alarm-notification tap to the alarm screen.
+///
+/// `onDidReceiveNotificationResponse` only fires while the Dart isolate is
+/// alive, so a tap that *launches* the app from a terminated state is delivered
+/// only via the launch details. Call this once during app startup.
+Future<void> handleNotificationLaunch() async {
+  if (!_supportsAlarmScheduling) {
+    return;
+  }
+  try {
+    final plugin = FlutterLocalNotificationsPlugin();
+    final details = await plugin.getNotificationAppLaunchDetails();
+    if (details == null || !details.didNotificationLaunchApp) {
+      return;
+    }
+    final response = details.notificationResponse;
+    if (response != null) {
+      // Same path as a live tap: body tap -> open the alarm screen, action
+      // button -> snooze/silence.
+      await _handleNotificationResponse(response);
+    }
+  } catch (error, stackTrace) {
+    debugPrint('Failed to handle notification launch: $error');
+    debugPrint('$stackTrace');
+  }
+}
+
+@pragma('vm:entry-point')
 Future<void> _handleNotificationResponse(NotificationResponse response) async {
+  // May run in a background isolate (an action button pressed while the app is
+  // terminated), so ensure plugins/DB are available there. No-op in foreground.
+  WidgetsFlutterBinding.ensureInitialized();
+  ui.DartPluginRegistrant.ensureInitialized();
   final payload = response.payload;
   if (payload == null || payload.isEmpty) {
     return;
@@ -792,7 +827,15 @@ void _navigateToAlarm(String thermostatId) {
   void attemptNavigation() {
     final context = rootNavigatorKey.currentContext;
     if (context != null) {
-      GoRouter.of(context).push(AlarmRoute.pathFor(thermostatId));
+      final target = AlarmRoute.pathFor(thermostatId);
+      final router = GoRouter.of(context);
+      // Don't stack a duplicate alarm page if this thermostat's alarm is already
+      // on top (the ongoing notification is re-posted every cycle and may be
+      // re-tapped) — pushing again would also drop the wakelock early when the
+      // duplicate is popped.
+      if (router.routerDelegate.currentConfiguration.uri.path != target) {
+        router.push(target);
+      }
       return;
     }
     if (attempts++ >= maxAttempts) {

--- a/app/lib/features/settings/view/settings_page.dart
+++ b/app/lib/features/settings/view/settings_page.dart
@@ -440,13 +440,21 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
   }
 
   Future<void> _testGithubToken() async {
-    final config = await ref.read(alertConfigRepositoryProvider).loadConfig();
-    final client = ThermostatHttpClient(githubToken: config.githubToken);
-    final message = await client.testToken();
-    if (!mounted) return;
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(message)));
+    try {
+      final config = await ref.read(alertConfigRepositoryProvider).loadConfig();
+      final client = ThermostatHttpClient(githubToken: config.githubToken);
+      final message = await client.testToken();
+      client.close();
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(message)));
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed to test GitHub token: $error')),
+      );
+    }
   }
 }
 
@@ -497,6 +505,15 @@ class _SettingsContentState extends State<_SettingsContent> {
   void initState() {
     super.initState();
     _tokenController = TextEditingController(text: widget.config.githubToken);
+    // Rebuild on each keystroke so the suffix Clear (×) icon, which is rendered
+    // conditionally on the field being non-empty, tracks the text.
+    _tokenController.addListener(_onTokenChanged);
+  }
+
+  void _onTokenChanged() {
+    if (mounted) {
+      setState(() {});
+    }
   }
 
   @override
@@ -509,6 +526,7 @@ class _SettingsContentState extends State<_SettingsContent> {
 
   @override
   void dispose() {
+    _tokenController.removeListener(_onTokenChanged);
     _tokenController.dispose();
     super.dispose();
   }

--- a/app/lib/features/thermostats/data/thermostat_client.dart
+++ b/app/lib/features/thermostats/data/thermostat_client.dart
@@ -107,6 +107,14 @@ class ThermostatHttpClient implements ThermostatNetworkDataSource {
   bool get hasGithubToken => _hasGithubToken;
   String? get resolvedToken => _resolvedToken;
 
+  /// Closes the underlying Dio clients. Call this for short-lived clients (e.g.
+  /// the per-submit token-validation client) so their HttpClients/sockets are
+  /// released rather than left to idle-timeout.
+  void close() {
+    _dio.close(force: true);
+    _dioNoAuth.close(force: true);
+  }
+
   @override
   Future<ThermostatFetchSuccess> fetchCurrent(String gistId) async {
     try {

--- a/app/lib/features/thermostats/data/thermostat_service.dart
+++ b/app/lib/features/thermostats/data/thermostat_service.dart
@@ -29,23 +29,21 @@ class ThermostatService {
       throw ThermostatValidationException(validation);
     }
 
-    final network = tokenOverride != null && tokenOverride.isNotEmpty
+    final overrideClient = tokenOverride != null && tokenOverride.isNotEmpty
         ? ThermostatHttpClient(
             githubToken: tokenOverride,
             allowAnonFallback: false,
           )
-        : _network;
-    final result = await network.fetchCurrent(draft.rawUrl.trim());
-    final saved = await _repository.create(draft);
-    await _repository.saveState(
-      thermostatId: saved.id,
-      status: ThermostatReadingStatus.ok,
-      valueC: result.valueC,
-      fetchedAt: result.fetchedAt,
-      etag: result.etag,
-      message: 'Fetched ${result.valueC.toStringAsFixed(2)}°C',
-    );
-    return saved;
+        : null;
+    final network = overrideClient ?? _network;
+    try {
+      final result = await network.fetchCurrent(draft.rawUrl.trim());
+      final saved = await _repository.create(draft);
+      await _saveTestedState(saved, result);
+      return saved;
+    } finally {
+      overrideClient?.close();
+    }
   }
 
   Future<Thermostat> updateAndTest(
@@ -58,23 +56,50 @@ class ThermostatService {
       throw ThermostatValidationException(validation);
     }
 
-    final network = tokenOverride != null && tokenOverride.isNotEmpty
+    final overrideClient = tokenOverride != null && tokenOverride.isNotEmpty
         ? ThermostatHttpClient(
             githubToken: tokenOverride,
             allowAnonFallback: false,
           )
-        : _network;
-    final result = await network.fetchCurrent(draft.rawUrl.trim());
-    final updated = await _repository.update(existing, draft);
+        : null;
+    final network = overrideClient ?? _network;
+    try {
+      final result = await network.fetchCurrent(draft.rawUrl.trim());
+      final updated = await _repository.update(existing, draft);
+      await _saveTestedState(updated, result);
+      return updated;
+    } finally {
+      overrideClient?.close();
+    }
+  }
+
+  /// Persists the result of a test fetch, evaluating the value against the
+  /// thermostat's (possibly just-changed) range so an active out-of-range
+  /// condition is not cleared to "ok" just because the user edited the
+  /// thermostat. Mirrors [refresh].
+  Future<void> _saveTestedState(
+    Thermostat thermostat,
+    ThermostatFetchSuccess result,
+  ) async {
+    final value = result.valueC;
+    final previousState = await _repository.loadState(thermostat.id);
+    final outOfRange = isThermostatReadingOutOfRange(
+      thermostat: thermostat,
+      currentValue: value,
+      previousState: previousState,
+    );
     await _repository.saveState(
-      thermostatId: updated.id,
-      status: ThermostatReadingStatus.ok,
-      valueC: result.valueC,
+      thermostatId: thermostat.id,
+      status: outOfRange
+          ? ThermostatReadingStatus.outOfRange
+          : ThermostatReadingStatus.ok,
+      valueC: value,
       fetchedAt: result.fetchedAt,
       etag: result.etag,
-      message: 'Fetched ${result.valueC.toStringAsFixed(2)}°C',
+      message: outOfRange
+          ? formatOutOfRangeThermostatMessage(thermostat, value)
+          : 'Fetched ${value.toStringAsFixed(2)}°C',
     );
-    return updated;
   }
 
   Future<ThermostatRefreshResult> refresh(Thermostat thermostat) async {

--- a/app/lib/features/thermostats/utils/thermostat_history_downsampler.dart
+++ b/app/lib/features/thermostats/utils/thermostat_history_downsampler.dart
@@ -33,7 +33,6 @@ class ThermostatHistoryDownsampler {
         () => _SampleBucket(
           thermostatId: sample.thermostatId,
           bucketStart: bucketStart,
-          bucketSeconds: bucketSeconds,
         ),
       );
       bucket.add(sample);
@@ -66,23 +65,20 @@ class ThermostatHistoryDownsampler {
 }
 
 class _SampleBucket {
-  _SampleBucket({
-    required this.thermostatId,
-    required this.bucketStart,
-    required this.bucketSeconds,
-  });
+  _SampleBucket({required this.thermostatId, required this.bucketStart});
 
   final String thermostatId;
   final DateTime bucketStart;
-  final int bucketSeconds;
 
   double _sum = 0;
   int _count = 0;
+  int _observedSumMs = 0;
   String? _firstSourceId;
 
   void add(TemperatureSample sample) {
     _sum += sample.valueC;
     _count += 1;
+    _observedSumMs += sample.observedAt.toUtc().millisecondsSinceEpoch;
     _firstSourceId ??= sample.sourceId;
   }
 
@@ -92,13 +88,13 @@ class _SampleBucket {
     }
 
     final average = _sum / _count;
-    final representative = bucketStart.add(
-      Duration(seconds: bucketSeconds ~/ 2),
+    // Plot at the mean of the contained samples' actual timestamps rather than
+    // the bucket centre, so a partially-filled (e.g. trailing) bucket isn't
+    // shifted forward in time — possibly past now — relative to its real data.
+    final observedAt = DateTime.fromMillisecondsSinceEpoch(
+      (_observedSumMs / _count).round(),
+      isUtc: true,
     );
-
-    final observedAt = representative.isUtc
-        ? representative
-        : representative.toUtc();
 
     return TemperatureSample(
       id: '${thermostatId}_bucket_${bucketStart.millisecondsSinceEpoch}_${range.name}',

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -13,4 +13,8 @@ Future<void> main() async {
     debugPrint('$stackTrace');
   }
   runApp(const ProviderScope(child: FarmCtlApp()));
+
+  // If the app was cold-launched by tapping an alarm notification, route to the
+  // alarm screen once the router is ready.
+  await handleNotificationLaunch();
 }

--- a/app/test/unit/thermostat_history_downsampler_test.dart
+++ b/app/test/unit/thermostat_history_downsampler_test.dart
@@ -41,10 +41,12 @@ void main() {
       // Two 10-minute buckets: [12:00–12:10) and [12:10–12:20)
       expect(result, hasLength(2));
       expect(result.first.valueC, closeTo(18.25, 1e-9));
-      expect(result.first.observedAt, DateTime.utc(2025, 1, 1, 12, 5));
+      // Representative time is the mean of the contained samples (12:00, 12:05),
+      // not the bucket centre.
+      expect(result.first.observedAt, DateTime.utc(2025, 1, 1, 12, 2, 30));
       expect(result.last.valueC, closeTo(19.0, 1e-9));
-      // Representative time is bucket midpoint (12:15)
-      expect(result.last.observedAt, DateTime.utc(2025, 1, 1, 12, 15));
+      // Single-sample bucket maps to that sample's own time (12:10), not 12:15.
+      expect(result.last.observedAt, DateTime.utc(2025, 1, 1, 12, 10));
     });
 
     test('downsamples to 5-minute buckets for hour range', () {
@@ -69,13 +71,20 @@ void main() {
       // 60 minutes / 5-minute buckets = 12 buckets
       expect(result.length, 12);
 
-      // First bucket [0..299]
+      // First bucket [0..299] — representative is the mean of the contained
+      // observedAt values (seconds 0..299 -> 149.5s), not the bucket centre.
       expect(result.first.valueC, closeTo(149.5, 1e-9));
-      expect(result.first.observedAt, start.add(const Duration(seconds: 150)));
+      expect(
+        result.first.observedAt,
+        start.add(const Duration(milliseconds: 149500)),
+      );
 
-      // Last bucket [3300..3599]
+      // Last bucket [3300..3599] -> mean 3449.5s
       expect(result.last.valueC, closeTo(3449.5, 1e-9));
-      expect(result.last.observedAt, start.add(const Duration(seconds: 3450)));
+      expect(
+        result.last.observedAt,
+        start.add(const Duration(milliseconds: 3449500)),
+      );
 
       for (var i = 1; i < result.length; i += 1) {
         expect(
@@ -83,6 +92,43 @@ void main() {
           isFalse,
         );
       }
+    });
+
+    test('trailing partial bucket is not shifted into the future', () {
+      // A dense first bucket, then a single recent sample alone in the trailing
+      // bucket. The trailing point must be plotted at its real time, never later.
+      final base = DateTime.utc(2025, 1, 1, 0, 0);
+      final samples = <TemperatureSample>[
+        for (var i = 0; i < 3; i++)
+          TemperatureSample(
+            id: 'a$i',
+            thermostatId: 't1',
+            valueC: 10.0 + i,
+            observedAt: base.add(Duration(minutes: i * 20)), // 0, 20, 40 min
+            source: 'revision',
+            sourceId: 'rev-a$i',
+          ),
+        // Lands ~5 min into the next 60-min (week) bucket.
+        TemperatureSample(
+          id: 'recent',
+          thermostatId: 't1',
+          valueC: 21.0,
+          observedAt: base.add(const Duration(minutes: 65)),
+          source: 'revision',
+          sourceId: 'rev-recent',
+        ),
+      ];
+
+      final result = ThermostatHistoryDownsampler.downsample(
+        samples,
+        ThermostatHistoryRange.week,
+      );
+
+      final last = result.last;
+      expect(last.valueC, closeTo(21.0, 1e-9));
+      // Plotted at the sample's own time, not the bucket midpoint (~90 min).
+      expect(last.observedAt, base.add(const Duration(minutes: 65)));
+      expect(last.observedAt.isAfter(samples.last.observedAt), isFalse);
     });
   });
 }

--- a/app/test/unit/thermostat_service_test.dart
+++ b/app/test/unit/thermostat_service_test.dart
@@ -139,6 +139,62 @@ void main() {
     expect(state.statusMessage, 'Fetched 9.00°C');
   });
 
+  test(
+    'updateAndTest keeps out-of-range when the new range excludes the value',
+    () async {
+      final created = await service.createAndTest(
+        ThermostatDraft(
+          name: 'Kiln',
+          rawUrl: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+          minC: 0,
+          maxC: 200,
+        ),
+      );
+      // 14.2 is within 0..200 -> ok after create.
+      expect(
+        (await repository.loadState(created.id))!.status,
+        ThermostatReadingStatus.ok,
+      );
+
+      // Editing to a range that excludes the (unchanged) reading must NOT clear
+      // the out-of-range condition to ok.
+      await service.updateAndTest(
+        created,
+        ThermostatDraft(
+          name: 'Kiln',
+          rawUrl: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+          minC: 0,
+          maxC: 10,
+        ),
+      );
+
+      final state = await repository.loadState(created.id);
+      expect(state!.status, ThermostatReadingStatus.outOfRange);
+      expect(state.statusMessage, contains('Out of range'));
+    },
+  );
+
+  test(
+    'createAndTest persists out-of-range when the initial value violates the range',
+    () async {
+      network._result = ThermostatFetchSuccess(
+        valueC: 95.0,
+        fetchedAt: DateTime.utc(2025, 1, 1, 12),
+        etag: 'e',
+      );
+      final created = await service.createAndTest(
+        ThermostatDraft(
+          name: 'Furnace',
+          rawUrl: 'ffffffffffffffffffffffffffffffff',
+          minC: 0,
+          maxC: 40,
+        ),
+      );
+      final state = await repository.loadState(created.id);
+      expect(state!.status, ThermostatReadingStatus.outOfRange);
+    },
+  );
+
   test('createAndTest rethrows fetch errors', () async {
     network._exception = const ThermostatFetchException(
       status: ThermostatReadingStatus.networkError,


### PR DESCRIPTION
Fixes the 7 confirmed findings from the third bug hunt, which targeted the UI / chart / settings / routing / lifecycle layer the first two (data-focused) hunts didn't reach. Full triage in `.agent/bug-hunt-ui-2026-06-27.md`.

## Fixed (2 high, 2 medium, 3 low)
**Alarm acknowledgement (high):**
- **UI-01** — a cold-launched app never opened the in-app alarm screen on notification tap. Added `handleNotificationLaunch()` (reads `getNotificationAppLaunchDetails()` from `main()`) and registered `onDidReceiveBackgroundNotificationResponse` so taps **and** action buttons work from a terminated state.
- **UI-02** — re-tapping the re-posted ongoing notification stacked a duplicate alarm page and dropped the wakelock early. `_navigateToAlarm` now skips the push when that alarm route is already on top.

**State/chart correctness (medium):**
- **UI-03** — the history downsampler plotted each bucket at its centre regardless of the samples' real times, pushing the newest point up to half a bucket into the future. Now plots at the mean of the contained samples' `observedAt`.
- **UI-04** — editing a thermostat cleared an active out-of-range state to "ok". `createAndTest`/`updateAndTest` now evaluate the range before saving, mirroring `refresh()`.

**Hygiene/feedback (low):**
- **UI-05** — `_testGithubToken` had no error handling (silent no-op on a storage failure); added try/catch + snackbar.
- **UI-06** — the token field's Clear (×) icon didn't track typing; added a controller listener.
- **UI-07** — the per-submit token-validation `ThermostatHttpClient` was never closed; added `close()` + a `finally`.

## Tests & quality
- App tests **104 → 107** (downsampler timestamps incl. a trailing-bucket regression; edit-out-of-range create/update). App coverage **35.1%**, parsing **100%**; both gates pass; analyze/format clean.
- UI-01/UI-02 are notification/navigation integration code, verified by analyze + reasoning (a unit test there would exercise the plugin/framework, not the logic) — the alarm-decision logic remains unit-tested.

## Open questions
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)