### PR TITLE
Monitoring verification, audit fixes & coverage to 60%

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
       # Floor / regression guard (hand-written code only; generated *.g.dart /
       # *.freezed.dart are excluded). Ratcheted up as coverage improves.
       - name: Enforce coverage threshold
-        run: bash tool/check_coverage.sh 45
+        run: bash tool/check_coverage.sh 60
 
       - name: Assemble debug APK
         run: flutter build apk --debug

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,9 +56,10 @@ jobs:
         run: flutter test --coverage
         working-directory: app
 
-      # Floor / regression guard, ratcheted up as coverage improves (toward 85%).
+      # Floor / regression guard (hand-written code only; generated *.g.dart /
+      # *.freezed.dart are excluded). Ratcheted up as coverage improves.
       - name: Enforce coverage threshold
-        run: bash tool/check_coverage.sh 31
+        run: bash tool/check_coverage.sh 45
 
       - name: Assemble debug APK
         run: flutter build apk --debug

--- a/app/lib/core/background/thermostat_monitor.dart
+++ b/app/lib/core/background/thermostat_monitor.dart
@@ -695,7 +695,11 @@ typedef _NotificationResponseHandler =
 
 Future<void> _initializeNotifications(
   FlutterLocalNotificationsPlugin plugin, {
-  _NotificationResponseHandler? onDidReceiveNotificationResponse,
+  // Defaults to the real handler so a caller that re-initialises the plugin in
+  // the app isolate (e.g. the Settings "test alarm") can't null out the
+  // foreground notification-tap handler that routes to the alarm screen.
+  _NotificationResponseHandler? onDidReceiveNotificationResponse =
+      _handleNotificationResponse,
   AlertConfig? config,
 }) async {
   const initializationSettings = InitializationSettings(

--- a/app/lib/core/background/thermostat_monitor.dart
+++ b/app/lib/core/background/thermostat_monitor.dart
@@ -52,6 +52,19 @@ const int _alarmRequestId = 5001;
 // failure).
 const Duration _monitorRunDebounce = Duration(seconds: 10);
 
+// Used to keep the one-shot alarm chain alive when the real config can't be
+// loaded (e.g. a transient DB/secure-storage failure), so polling doesn't
+// silently drop to the WorkManager floor.
+const AlertConfig _fallbackConfig = AlertConfig(
+  pollInterval: Duration(minutes: 5),
+  exactAlarmsEnabled: false,
+  soundUri: null,
+  vibrate: true,
+  volumeBoost: false,
+  pauseAllUntil: null,
+  githubToken: null,
+);
+
 bool _alarmManagerInitialized = false;
 
 bool get _supportsAlarmScheduling => !kIsWeb && Platform.isAndroid;
@@ -76,7 +89,10 @@ Future<void> _ensureAlarmManagerInitialized() async {
   }
 }
 
-DateTime? _computeNextAlarmTime(AlertConfig config, DateTime nowUtc) {
+/// The next time (UTC) the monitor should run: `now + pollInterval`, deferred to
+/// the end of an active pause. Returns null when the interval is non-positive
+/// (monitoring effectively off). Pure so the polling cadence is unit-testable.
+DateTime? nextMonitorRunUtc(AlertConfig config, DateTime nowUtc) {
   final interval = config.pollInterval;
   if (interval <= Duration.zero) {
     return null;
@@ -88,7 +104,19 @@ DateTime? _computeNextAlarmTime(AlertConfig config, DateTime nowUtc) {
     target = pauseUntil;
   }
 
-  return target.toLocal();
+  return target;
+}
+
+/// The effective WorkManager periodic frequency: the configured interval clamped
+/// up to the 15-minute platform minimum. Pure for testability.
+Duration effectiveMonitorFrequency(Duration configuredInterval) {
+  return configuredInterval < _minimumFrequency
+      ? _minimumFrequency
+      : configuredInterval;
+}
+
+DateTime? _computeNextAlarmTime(AlertConfig config, DateTime nowUtc) {
+  return nextMonitorRunUtc(config, nowUtc)?.toLocal();
 }
 
 Future<void> _updateAlarmSchedule(AlertConfig config, {DateTime? now}) async {
@@ -191,9 +219,7 @@ Future<void> initializeBackgroundMonitoring({Duration? pollFrequency}) async {
 
   final configuredInterval =
       pollFrequency ?? config?.pollInterval ?? const Duration(minutes: 5);
-  final effectiveFrequency = configuredInterval < _minimumFrequency
-      ? _minimumFrequency
-      : configuredInterval;
+  final effectiveFrequency = effectiveMonitorFrequency(configuredInterval);
 
   await Workmanager().initialize(thermostatMonitorCallbackDispatcher);
   await Workmanager().registerPeriodicTask(
@@ -278,6 +304,10 @@ Future<bool> _runMonitorTask() async {
   if (config == null) {
     debugPrint('Alert config unavailable; skipping monitor run.');
     await database.close();
+    // Keep the one-shot alarm chain alive at a safe default cadence so polling
+    // doesn't silently drop to the WorkManager floor while the config is
+    // transiently unreadable.
+    await _updateAlarmSchedule(_fallbackConfig);
     // Treat a failed config load as a failure so WorkManager retries.
     return false;
   }

--- a/app/lib/features/settings/view/settings_page.dart
+++ b/app/lib/features/settings/view/settings_page.dart
@@ -443,8 +443,12 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
     try {
       final config = await ref.read(alertConfigRepositoryProvider).loadConfig();
       final client = ThermostatHttpClient(githubToken: config.githubToken);
-      final message = await client.testToken();
-      client.close();
+      final String message;
+      try {
+        message = await client.testToken();
+      } finally {
+        client.close();
+      }
       if (!mounted) return;
       ScaffoldMessenger.of(
         context,

--- a/app/lib/features/thermostats/data/thermostat_database.dart
+++ b/app/lib/features/thermostats/data/thermostat_database.dart
@@ -193,15 +193,23 @@ class ThermostatDatabase extends _$ThermostatDatabase {
       }
       if (from < 8) {
         // A pre-fix concurrent-insert race could leave duplicate alert_config
-        // rows; collapse them into the single canonical row (id = 1). Keep a
-        // row that still holds a plaintext token if any (so it can be migrated
-        // to secure storage), otherwise the lowest id.
+        // rows. The LOWEST-id row is the live/canonical one (reads use
+        // id ASC LIMIT 1, writes upsert id = 1); any higher-id duplicate is a
+        // frozen leftover. Keep the live row's settings, forward-fill any
+        // still-plaintext token from a duplicate (so it can be migrated to
+        // secure storage), then drop the rest and pin to id = 1.
         await customStatement('''
-          DELETE FROM alert_config_entries WHERE id NOT IN (
-            SELECT id FROM alert_config_entries
-            ORDER BY (github_token IS NOT NULL) DESC, id ASC
-            LIMIT 1
+          UPDATE alert_config_entries
+          SET github_token = COALESCE(
+            github_token,
+            (SELECT github_token FROM alert_config_entries
+             WHERE github_token IS NOT NULL ORDER BY id ASC LIMIT 1)
           )
+          WHERE id = (SELECT MIN(id) FROM alert_config_entries)
+        ''');
+        await customStatement('''
+          DELETE FROM alert_config_entries
+          WHERE id <> (SELECT MIN(id) FROM alert_config_entries)
         ''');
         await customStatement('UPDATE alert_config_entries SET id = 1');
       }

--- a/app/lib/features/thermostats/data/thermostat_database.dart
+++ b/app/lib/features/thermostats/data/thermostat_database.dart
@@ -144,7 +144,7 @@ class ThermostatDatabase extends _$ThermostatDatabase {
   ThermostatDatabase.forTesting(super.executor);
 
   @override
-  int get schemaVersion => 7;
+  int get schemaVersion => 8;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -190,6 +190,20 @@ class ThermostatDatabase extends _$ThermostatDatabase {
           alertConfigEntries,
           alertConfigEntries.lastMonitorRunAt,
         );
+      }
+      if (from < 8) {
+        // A pre-fix concurrent-insert race could leave duplicate alert_config
+        // rows; collapse them into the single canonical row (id = 1). Keep a
+        // row that still holds a plaintext token if any (so it can be migrated
+        // to secure storage), otherwise the lowest id.
+        await customStatement('''
+          DELETE FROM alert_config_entries WHERE id NOT IN (
+            SELECT id FROM alert_config_entries
+            ORDER BY (github_token IS NOT NULL) DESC, id ASC
+            LIMIT 1
+          )
+        ''');
+        await customStatement('UPDATE alert_config_entries SET id = 1');
       }
     },
   );

--- a/app/lib/features/thermostats/data/thermostat_service.dart
+++ b/app/lib/features/thermostats/data/thermostat_service.dart
@@ -88,17 +88,33 @@ class ThermostatService {
       currentValue: value,
       previousState: previousState,
     );
+
+    if (outOfRange) {
+      await _repository.saveState(
+        thermostatId: thermostat.id,
+        status: ThermostatReadingStatus.outOfRange,
+        valueC: value,
+        fetchedAt: result.fetchedAt,
+        etag: result.etag,
+        message: formatOutOfRangeThermostatMessage(thermostat, value),
+      );
+      return;
+    }
+
+    // OK reading: clear any snooze/silence, exactly as refresh() does — otherwise
+    // editing a snoozed/silenced thermostat to an in-range value would leave the
+    // suppression in place and mute the next genuine out-of-range alarm.
     await _repository.saveState(
       thermostatId: thermostat.id,
-      status: outOfRange
-          ? ThermostatReadingStatus.outOfRange
-          : ThermostatReadingStatus.ok,
+      status: ThermostatReadingStatus.ok,
       valueC: value,
       fetchedAt: result.fetchedAt,
       etag: result.etag,
-      message: outOfRange
-          ? formatOutOfRangeThermostatMessage(thermostat, value)
-          : 'Fetched ${value.toStringAsFixed(2)}°C',
+      message: 'Fetched ${value.toStringAsFixed(2)}°C',
+      setSnoozedUntil: previousState?.snoozedUntil != null,
+      snoozedUntil: null,
+      setSilenceUntilOk: previousState?.silenceUntilOk == true,
+      silenceUntilOk: false,
     );
   }
 

--- a/app/test/unit/history_range_test.dart
+++ b/app/test/unit/history_range_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:farmctl/features/thermostats/models/history_range.dart';
+
+void main() {
+  group('ThermostatHistoryRange', () {
+    test('window matches the named span; "All" is unbounded', () {
+      expect(ThermostatHistoryRange.hour.window, const Duration(hours: 1));
+      expect(ThermostatHistoryRange.day.window, const Duration(days: 1));
+      expect(ThermostatHistoryRange.week.window, const Duration(days: 7));
+      expect(ThermostatHistoryRange.month.window, const Duration(days: 30));
+      expect(ThermostatHistoryRange.year.window, const Duration(days: 365));
+      expect(ThermostatHistoryRange.all.window, isNull);
+    });
+
+    test('every value has a distinct, non-empty label and description', () {
+      final labels = <String>{};
+      final descriptions = <String>{};
+      for (final range in ThermostatHistoryRange.values) {
+        expect(range.label, isNotEmpty);
+        expect(range.description, isNotEmpty);
+        labels.add(range.label);
+        descriptions.add(range.description);
+      }
+      expect(labels, hasLength(ThermostatHistoryRange.values.length));
+      expect(descriptions, hasLength(ThermostatHistoryRange.values.length));
+      expect(ThermostatHistoryRange.day.label, '24H');
+      expect(ThermostatHistoryRange.all.label, 'All');
+    });
+
+    group('thermostatHistoryRangeFromName', () {
+      test('round-trips every enum name', () {
+        for (final range in ThermostatHistoryRange.values) {
+          expect(thermostatHistoryRangeFromName(range.name), range);
+        }
+      });
+
+      test('returns null for null, empty, or unknown names', () {
+        // Guards the history route's ?range= query-param parse against bad input.
+        expect(thermostatHistoryRangeFromName(null), isNull);
+        expect(thermostatHistoryRangeFromName(''), isNull);
+        expect(thermostatHistoryRangeFromName('decade'), isNull);
+        expect(
+          thermostatHistoryRangeFromName('Hour'),
+          isNull,
+        ); // case-sensitive
+      });
+    });
+  });
+}

--- a/app/test/unit/offline_status_provider_test.dart
+++ b/app/test/unit/offline_status_provider_test.dart
@@ -161,4 +161,89 @@ void main() {
       expect(status, OfflineStatus.online);
     },
   );
+
+  ProviderContainer containerWith(List<ThermostatSummary> summaries) {
+    final container = ProviderContainer(
+      overrides: [
+        nowProvider.overrideWithValue(() => fixedNow),
+        thermostatsProvider.overrideWith((ref) => Stream.value(summaries)),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  ThermostatSummary summaryWith(
+    String id,
+    ThermostatReadingStatus status, {
+    required DateTime fetchedAt,
+  }) {
+    return ThermostatSummary(
+      thermostat: createThermostat(id),
+      state: createState(
+        thermostatId: id,
+        status: status,
+        lastFetchedAt: fetchedAt,
+      ),
+    );
+  }
+
+  test('online when there are no thermostats', () async {
+    expect(await readStatus(containerWith([])), OfflineStatus.online);
+  });
+
+  test('online when the only network error is older than 30 minutes', () async {
+    final container = containerWith([
+      summaryWith(
+        '1',
+        ThermostatReadingStatus.networkError,
+        fetchedAt: fixedNow.subtract(const Duration(minutes: 40)),
+      ),
+    ]);
+    expect(await readStatus(container), OfflineStatus.online);
+  });
+
+  test(
+    'offline when a recent failure coexists with only stale successes',
+    () async {
+      final container = containerWith([
+        summaryWith(
+          '1',
+          ThermostatReadingStatus.networkError,
+          fetchedAt: fixedNow.subtract(const Duration(minutes: 10)),
+        ),
+        summaryWith(
+          '2',
+          ThermostatReadingStatus.ok,
+          // Older than the 15-minute "recent success" window.
+          fetchedAt: fixedNow.subtract(const Duration(minutes: 20)),
+        ),
+      ]);
+      expect(await readStatus(container), OfflineStatus.offline);
+    },
+  );
+
+  test('httpError is not treated as a connectivity failure', () async {
+    final container = containerWith([
+      summaryWith(
+        '1',
+        ThermostatReadingStatus.httpError,
+        fetchedAt: fixedNow.subtract(const Duration(minutes: 5)),
+      ),
+    ]);
+    expect(await readStatus(container), OfflineStatus.online);
+  });
+
+  test('unknown while the thermostats stream is loading/errored', () async {
+    final container = ProviderContainer(
+      overrides: [
+        nowProvider.overrideWithValue(() => fixedNow),
+        thermostatsProvider.overrideWith(
+          (ref) => Stream<List<ThermostatSummary>>.error(Exception('boom')),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    expect(container.read(offlineStatusProvider), OfflineStatus.unknown);
+  });
 }

--- a/app/test/unit/thermostat_client_test.dart
+++ b/app/test/unit/thermostat_client_test.dart
@@ -390,4 +390,97 @@ void main() {
       expect(anonCalled, isFalse);
     },
   );
+
+  final jsonHeaders = {
+    Headers.contentTypeHeader: [ContentType.json.mimeType],
+  };
+
+  test('testToken reports the rate-limit summary on success', () async {
+    final dio = Dio()
+      ..httpClientAdapter = _FakeAdapter((options) async {
+        return ResponseBody.fromString(
+          '{"resources":{"core":{"remaining":42,"limit":5000}}}',
+          200,
+          headers: jsonHeaders,
+        );
+      });
+    final client = ThermostatHttpClient(dio: dio);
+
+    final message = await client.testToken();
+    expect(message, contains('remaining 42'));
+    expect(message, contains('5000'));
+  });
+
+  test('testToken reports an auth error on failure', () async {
+    final dio = Dio()
+      ..httpClientAdapter = _FakeAdapter((options) async {
+        return ResponseBody.fromString('{"message":"Bad credentials"}', 401);
+      });
+    final client = ThermostatHttpClient(dio: dio, githubToken: 'bad');
+
+    final message = await client.testToken();
+    expect(message.toLowerCase(), contains('error'));
+  });
+
+  test('listCommits returns parsed, ordered commits', () async {
+    final dio = Dio()
+      ..httpClientAdapter = _FakeAdapter((options) async {
+        return ResponseBody.fromString(
+          '[{"version":"rev1","committed_at":"2025-01-02T10:00:00Z"},'
+          '{"version":"rev2","committed_at":"2025-01-02T12:00:00Z"}]',
+          200,
+          headers: jsonHeaders,
+        );
+      });
+    final client = ThermostatHttpClient(dio: dio);
+
+    final commits = await client.listCommits(
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    );
+    expect(commits, hasLength(2));
+    expect(commits.first.revisionId, 'rev1');
+    expect(commits.last.observedAt, DateTime.utc(2025, 1, 2, 12));
+  });
+
+  test('fetchRevisionValue parses a single revision snapshot', () async {
+    final dio = Dio()
+      ..httpClientAdapter = _FakeAdapter((options) async {
+        return ResponseBody.fromString(
+          '{"files":{"thermostat.txt":{"truncated":false,"content":"Temperature: 9.9 C"}}}',
+          200,
+          headers: jsonHeaders,
+        );
+      });
+    final client = ThermostatHttpClient(dio: dio);
+
+    final value = await client.fetchRevisionValue(
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      'rev1',
+    );
+    expect(value, closeTo(9.9, 1e-9));
+  });
+
+  test(
+    'fetches the raw_url when the inline gist content is truncated',
+    () async {
+      final dio = Dio()
+        ..httpClientAdapter = _FakeAdapter((options) async {
+          if (options.path.contains('raw-host')) {
+            return ResponseBody.fromString('Temperature: 7.7 C', 200);
+          }
+          return ResponseBody.fromString(
+            '{"files":{"thermostat.txt":{"truncated":true,'
+            '"raw_url":"https://raw-host.example/x"}}}',
+            200,
+            headers: jsonHeaders,
+          );
+        });
+      final client = ThermostatHttpClient(dio: dio);
+
+      final result = await client.fetchCurrent(
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      );
+      expect(result.valueC, closeTo(7.7, 1e-9));
+    },
+  );
 }

--- a/app/test/unit/thermostat_database_migration_test.dart
+++ b/app/test/unit/thermostat_database_migration_test.dart
@@ -98,8 +98,8 @@ void main() {
     },
   );
 
-  test('upgrades from v1 to v7 without duplicate-column errors', () async {
-    // Build v7, seed a thermostat, then strip everything added after v1.
+  test('upgrades from v1 to latest without duplicate-column errors', () async {
+    // Build the latest schema, seed a thermostat, then strip everything after v1.
     final db = openDb();
     await seedThermostat(db, 't1');
     await db.customStatement('DROP TABLE temperature_readings');
@@ -137,6 +137,36 @@ void main() {
     expect(state!.silenceUntilOk, isTrue);
 
     expect(await upgraded.listThermostats(), hasLength(1));
+    await upgraded.close();
+  });
+
+  test('upgrades v7 -> v8, consolidating duplicate alert_config rows', () async {
+    final db = openDb();
+    // Simulate the pre-fix duplicate-row state: id=1 with defaults (no token),
+    // id=2 with a token and a custom poll interval. Then rewind to v7.
+    await db.customStatement(
+      'INSERT INTO alert_config_entries '
+      '(id, poll_interval_min, exact_alarms_enabled, sound_uri, vibrate, '
+      'volume_boost, pause_all_until, github_token, last_monitor_run_at) '
+      'VALUES (1, 5, 0, NULL, 1, 0, NULL, NULL, NULL)',
+    );
+    await db.customStatement(
+      'INSERT INTO alert_config_entries '
+      '(id, poll_interval_min, exact_alarms_enabled, sound_uri, vibrate, '
+      'volume_boost, pause_all_until, github_token, last_monitor_run_at) '
+      "VALUES (2, 9, 1, NULL, 1, 0, NULL, 'ghp_seed', NULL)",
+    );
+    await db.customStatement('PRAGMA user_version = 7');
+    await db.close();
+
+    // Re-open: onUpgrade(7 -> 8) collapses to a single row, keeping the
+    // token-bearing one (so its plaintext token can still be migrated).
+    final upgraded = openDb();
+    final rows = await upgraded.select(upgraded.alertConfigEntries).get();
+    expect(rows, hasLength(1));
+    final config = await upgraded.getAlertConfig();
+    expect(config.githubToken, 'ghp_seed');
+    expect(config.pollIntervalMin, 9);
     await upgraded.close();
   });
 }

--- a/app/test/unit/thermostat_database_migration_test.dart
+++ b/app/test/unit/thermostat_database_migration_test.dart
@@ -142,8 +142,10 @@ void main() {
 
   test('upgrades v7 -> v8, consolidating duplicate alert_config rows', () async {
     final db = openDb();
-    // Simulate the pre-fix duplicate-row state: id=1 with defaults (no token),
-    // id=2 with a token and a custom poll interval. Then rewind to v7.
+    // Simulate the pre-fix duplicate-row state. id=1 is the LIVE row the app
+    // reads/writes (poll=5, exact alarms off, token already migrated to secure
+    // storage so the plaintext column is null); id=2 is a frozen leftover that
+    // still holds an old plaintext token and stale settings. Then rewind to v7.
     await db.customStatement(
       'INSERT INTO alert_config_entries '
       '(id, poll_interval_min, exact_alarms_enabled, sound_uri, vibrate, '
@@ -159,14 +161,17 @@ void main() {
     await db.customStatement('PRAGMA user_version = 7');
     await db.close();
 
-    // Re-open: onUpgrade(7 -> 8) collapses to a single row, keeping the
-    // token-bearing one (so its plaintext token can still be migrated).
+    // Re-open: onUpgrade(7 -> 8) collapses to a single row, keeping the LIVE
+    // (lowest-id) row's settings and merging the duplicate's token forward.
     final upgraded = openDb();
     final rows = await upgraded.select(upgraded.alertConfigEntries).get();
     expect(rows, hasLength(1));
     final config = await upgraded.getAlertConfig();
+    // Live settings survive (NOT the stale id=2 values 9 / true)...
+    expect(config.pollIntervalMin, 5);
+    expect(config.exactAlarmsEnabled, isFalse);
+    // ...and the only token (from the duplicate) is forward-filled.
     expect(config.githubToken, 'ghp_seed');
-    expect(config.pollIntervalMin, 9);
     await upgraded.close();
   });
 }

--- a/app/test/unit/thermostat_models_test.dart
+++ b/app/test/unit/thermostat_models_test.dart
@@ -95,5 +95,24 @@ void main() {
       // copyWith cannot clear a nullable; withToken can.
       expect(base.withToken('ghp_x').withToken(null).githubToken, isNull);
     });
+
+    test('isPaused / remainingPause reflect the pause window', () {
+      final now = DateTime.utc(2025, 1, 1, 12);
+
+      expect(base.isPaused(now), isFalse);
+      expect(base.remainingPause(now), isNull);
+
+      final paused = base.copyWith(
+        pauseAllUntil: now.add(const Duration(hours: 2)),
+      );
+      expect(paused.isPaused(now), isTrue);
+      expect(paused.remainingPause(now), const Duration(hours: 2));
+
+      final expired = base.copyWith(
+        pauseAllUntil: now.subtract(const Duration(minutes: 1)),
+      );
+      expect(expired.isPaused(now), isFalse);
+      expect(expired.remainingPause(now), isNull);
+    });
   });
 }

--- a/app/test/unit/thermostat_monitor_runner_test.dart
+++ b/app/test/unit/thermostat_monitor_runner_test.dart
@@ -467,4 +467,51 @@ void main() {
     expect(state.snoozedUntil, isNull);
     expect(alarms.triggered, contains('${thermostat.id}::4.0'));
   });
+
+  test(
+    'run does not poll or alarm a thermostat with monitoring disabled',
+    () async {
+      final thermostat = await repository.create(
+        ThermostatDraft(
+          name: 'Disabled',
+          rawUrl: '99999999999999999999999999999999',
+          minC: 0,
+          maxC: 20,
+        ),
+      );
+      // Turn monitoring off for this thermostat.
+      await database.upsertThermostat(
+        ThermostatEntriesCompanion(
+          id: drift.Value(thermostat.id),
+          name: drift.Value(thermostat.name),
+          rawUrl: drift.Value(thermostat.rawUrl),
+          minC: drift.Value(thermostat.minC),
+          maxC: drift.Value(thermostat.maxC),
+          monitoringEnabled: const drift.Value(false),
+          createdAt: drift.Value(thermostat.createdAt),
+          updatedAt: drift.Value(thermostat.updatedAt),
+        ),
+      );
+
+      // An out-of-range value that WOULD alarm if the thermostat were monitored.
+      network._result = ThermostatFetchSuccess(
+        valueC: 99,
+        fetchedAt: DateTime.utc(2025, 1, 1, 12),
+        etag: 'etag-disabled',
+      );
+
+      final runner = ThermostatMonitorRunner(
+        repository: repository,
+        network: network,
+        alarmDispatcher: alarms,
+        clock: () => DateTime.utc(2025, 1, 1, 12),
+      );
+
+      await runner.run();
+
+      // It is skipped entirely: no reading is fetched/persisted and no alarm fires.
+      expect(await repository.loadState(thermostat.id), isNull);
+      expect(alarms.triggered, isEmpty);
+    },
+  );
 }

--- a/app/test/unit/thermostat_monitor_schedule_test.dart
+++ b/app/test/unit/thermostat_monitor_schedule_test.dart
@@ -1,6 +1,22 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:farmctl/core/background/thermostat_monitor.dart';
+import 'package:farmctl/features/settings/models/alert_config.dart';
+
+AlertConfig _config({
+  Duration interval = const Duration(minutes: 5),
+  DateTime? pauseUntil,
+}) {
+  return AlertConfig(
+    pollInterval: interval,
+    exactAlarmsEnabled: false,
+    soundUri: null,
+    vibrate: true,
+    volumeBoost: false,
+    pauseAllUntil: pauseUntil,
+    githubToken: null,
+  );
+}
 
 void main() {
   group('shouldSkipMonitorRun', () {
@@ -73,6 +89,81 @@ void main() {
       expect(snoozeDurationForAction('alarm_silence_until_ok'), isNull);
       expect(snoozeDurationForAction('something_else'), isNull);
       expect(snoozeDurationForAction(null), isNull);
+    });
+  });
+
+  group('nextMonitorRunUtc', () {
+    final now = DateTime.utc(2025, 1, 1, 12);
+
+    test('schedules the next run exactly one poll interval ahead', () {
+      expect(
+        nextMonitorRunUtc(_config(interval: const Duration(minutes: 1)), now),
+        now.add(const Duration(minutes: 1)),
+      );
+      expect(
+        nextMonitorRunUtc(_config(interval: const Duration(minutes: 5)), now),
+        now.add(const Duration(minutes: 5)),
+      );
+      expect(
+        nextMonitorRunUtc(_config(interval: const Duration(minutes: 30)), now),
+        now.add(const Duration(minutes: 30)),
+      );
+    });
+
+    test('returns null for a non-positive interval (monitoring off)', () {
+      expect(nextMonitorRunUtc(_config(interval: Duration.zero), now), isNull);
+    });
+
+    test('defers the next run to the end of an active pause', () {
+      final pauseUntil = now.add(const Duration(hours: 1));
+      expect(
+        nextMonitorRunUtc(
+          _config(interval: const Duration(minutes: 5), pauseUntil: pauseUntil),
+          now,
+        ),
+        pauseUntil,
+      );
+    });
+
+    test('ignores a pause that ends before the next interval', () {
+      final pauseUntil = now.add(const Duration(minutes: 2));
+      expect(
+        nextMonitorRunUtc(
+          _config(interval: const Duration(minutes: 5), pauseUntil: pauseUntil),
+          now,
+        ),
+        now.add(const Duration(minutes: 5)),
+      );
+    });
+  });
+
+  group('effectiveMonitorFrequency', () {
+    test('clamps sub-15-minute intervals up to the platform floor', () {
+      // WorkManager cannot run more often than every 15 minutes; the precise
+      // sub-15-minute cadence is driven by the AlarmManager one-shot instead.
+      expect(
+        effectiveMonitorFrequency(const Duration(minutes: 1)),
+        const Duration(minutes: 15),
+      );
+      expect(
+        effectiveMonitorFrequency(const Duration(minutes: 5)),
+        const Duration(minutes: 15),
+      );
+      expect(
+        effectiveMonitorFrequency(const Duration(minutes: 15)),
+        const Duration(minutes: 15),
+      );
+    });
+
+    test('honours intervals at or above the floor', () {
+      expect(
+        effectiveMonitorFrequency(const Duration(minutes: 20)),
+        const Duration(minutes: 20),
+      );
+      expect(
+        effectiveMonitorFrequency(const Duration(minutes: 30)),
+        const Duration(minutes: 30),
+      );
     });
   });
 }

--- a/app/test/unit/thermostat_repository_test.dart
+++ b/app/test/unit/thermostat_repository_test.dart
@@ -400,4 +400,51 @@ void main() {
       expect(state.lastAlarmAt, isNull);
     },
   );
+
+  test('findById, reading-time bounds and known revision ids', () async {
+    final thermostat = await repository.create(
+      ThermostatDraft(
+        name: 'History',
+        rawUrl: '77777777777777777777777777777777',
+        minC: 0,
+        maxC: 30,
+      ),
+    );
+
+    expect((await repository.findById(thermostat.id))?.id, thermostat.id);
+    expect(await repository.findById('does-not-exist'), isNull);
+
+    // No readings yet.
+    expect(await repository.getOldestReadingTime(thermostat.id), isNull);
+    expect(await repository.getNewestReadingTime(thermostat.id), isNull);
+    expect(await repository.listKnownRevisionIds(thermostat.id), isEmpty);
+
+    await repository.upsertHistory(
+      thermostatId: thermostat.id,
+      samples: [
+        TemperatureSample.revision(
+          thermostatId: thermostat.id,
+          revisionId: 'r1',
+          valueC: 10,
+          observedAt: DateTime.utc(2025, 1, 1, 10),
+        ),
+        TemperatureSample.revision(
+          thermostatId: thermostat.id,
+          revisionId: 'r2',
+          valueC: 11,
+          observedAt: DateTime.utc(2025, 1, 1, 12),
+        ),
+      ],
+    );
+
+    final oldest = await repository.getOldestReadingTime(thermostat.id);
+    final newest = await repository.getNewestReadingTime(thermostat.id);
+    expect(oldest, isNotNull);
+    expect(newest, isNotNull);
+    expect(newest!.isAfter(oldest!), isTrue);
+    expect(
+      await repository.listKnownRevisionIds(thermostat.id),
+      containsAll(<String>['r1', 'r2']),
+    );
+  });
 }

--- a/app/test/unit/thermostat_service_test.dart
+++ b/app/test/unit/thermostat_service_test.dart
@@ -195,6 +195,47 @@ void main() {
     },
   );
 
+  test('updateAndTest clears silence/snooze when back in range', () async {
+    final created = await service.createAndTest(
+      ThermostatDraft(
+        name: 'Vent',
+        rawUrl: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        minC: 10,
+        maxC: 20,
+      ),
+    );
+    // The thermostat is currently out of range, silenced and snoozed.
+    await repository.saveState(
+      thermostatId: created.id,
+      status: ThermostatReadingStatus.outOfRange,
+      valueC: 30,
+      fetchedAt: DateTime.utc(2025, 1, 1, 9),
+      etag: 'old',
+      message: 'Out of range',
+      setSilenceUntilOk: true,
+      silenceUntilOk: true,
+      setSnoozedUntil: true,
+      snoozedUntil: DateTime.utc(2025, 1, 1, 10),
+    );
+
+    // Edit it; the test fetch (14.2) is back inside the range.
+    await service.updateAndTest(
+      created,
+      ThermostatDraft(
+        name: 'Vent',
+        rawUrl: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        minC: 10,
+        maxC: 20,
+      ),
+    );
+
+    final state = await repository.loadState(created.id);
+    expect(state!.status, ThermostatReadingStatus.ok);
+    // Suppression must be cleared so a future out-of-range still alarms.
+    expect(state.silenceUntilOk, isFalse);
+    expect(state.snoozedUntil, isNull);
+  });
+
   test('createAndTest rethrows fetch errors', () async {
     network._exception = const ThermostatFetchException(
       status: ThermostatReadingStatus.networkError,

--- a/app/test/widget/alarm_fullscreen_page_test.dart
+++ b/app/test/widget/alarm_fullscreen_page_test.dart
@@ -81,4 +81,77 @@ void main() {
       );
     },
   );
+
+  Future<void> pumpStream(
+    WidgetTester tester,
+    Stream<ThermostatSummary?> stream,
+  ) async {
+    tester.view.physicalSize = const Size(420, 1200);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          thermostatSummaryProvider(thermostatId).overrideWith((ref) => stream),
+        ],
+        child: const MaterialApp(
+          home: AlarmFullScreenPage(thermostatId: thermostatId),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('shows a missing-thermostat message when the summary is null', (
+    tester,
+  ) async {
+    await pumpStream(tester, Stream<ThermostatSummary?>.value(null));
+    expect(find.text('Thermostat not found.'), findsOneWidget);
+  });
+
+  testWidgets('shows an error message when the summary stream fails', (
+    tester,
+  ) async {
+    await pumpStream(
+      tester,
+      Stream<ThermostatSummary?>.error(Exception('boom')),
+    );
+    expect(find.textContaining('Failed to load alarm details'), findsOneWidget);
+  });
+
+  testWidgets('surfaces snooze and silence status details', (tester) async {
+    final base = buildSummary();
+    final state = base.state!;
+    final snoozed = ThermostatSummary(
+      thermostat: base.thermostat,
+      state: ThermostatState(
+        thermostatId: state.thermostatId,
+        status: state.status,
+        lastValueC: state.lastValueC,
+        lastFetchedAt: state.lastFetchedAt,
+        statusMessage: state.statusMessage,
+        snoozedUntil: DateTime.utc(2030, 1, 1, 12),
+        silenceUntilOk: true,
+        createdAt: state.createdAt,
+        updatedAt: state.updatedAt,
+      ),
+    );
+
+    await pumpStream(tester, Stream<ThermostatSummary?>.value(snoozed));
+
+    expect(find.textContaining('Snoozed until'), findsOneWidget);
+    expect(
+      find.text('Silenced until reading returns to range.'),
+      findsOneWidget,
+    );
+    // The "Silence until OK" action is disabled while already silenced.
+    final silenceButton = tester.widget<OutlinedButton>(
+      find.ancestor(
+        of: find.text('Silence until OK'),
+        matching: find.byType(OutlinedButton),
+      ),
+    );
+    expect(silenceButton.onPressed, isNull);
+  });
 }

--- a/app/test/widget/thermostat_card_test.dart
+++ b/app/test/widget/thermostat_card_test.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:farmctl/features/thermostats/models/thermostat.dart';
+import 'package:farmctl/features/thermostats/models/thermostat_state.dart';
+import 'package:farmctl/features/thermostats/widgets/thermostat_card.dart';
+
+ThermostatSummary _summary({
+  ThermostatReadingStatus? status,
+  double? value,
+  String? message,
+  DateTime? fetchedAt,
+}) {
+  final timestamp = DateTime.utc(2025, 1, 1, 12);
+  return ThermostatSummary(
+    thermostat: Thermostat(
+      id: 'thermostat-1',
+      name: 'Greenhouse',
+      rawUrl: 'a' * 32,
+      minC: 10,
+      maxC: 20,
+      hysteresisEnabled: false,
+      monitoringEnabled: true,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    ),
+    state: status == null
+        ? null
+        : ThermostatState(
+            thermostatId: 'thermostat-1',
+            status: status,
+            lastValueC: value,
+            lastFetchedAt: fetchedAt,
+            statusMessage: message,
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          ),
+  );
+}
+
+Future<void> _pump(
+  WidgetTester tester,
+  ThermostatSummary summary, {
+  VoidCallback? onTap,
+  VoidCallback? onEdit,
+  VoidCallback? onDelete,
+  VoidCallback? onRefresh,
+}) {
+  return tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: ThermostatCard(
+            summary: summary,
+            onTap: onTap,
+            onEdit: onEdit,
+            onDelete: onDelete,
+            onRefresh: onRefresh,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  final recent = DateTime.now().toUtc().subtract(const Duration(minutes: 5));
+
+  testWidgets('renders an OK reading with temperature and range', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      _summary(
+        status: ThermostatReadingStatus.ok,
+        value: 15.0,
+        fetchedAt: recent,
+      ),
+    );
+
+    expect(find.text('Greenhouse'), findsOneWidget);
+    expect(find.text('15.0°C'), findsOneWidget);
+    expect(find.text('Current temperature'), findsOneWidget);
+    expect(find.text('10.0°C – 20.0°C'), findsOneWidget); // target-range chip
+    expect(find.text('Target range'), findsOneWidget);
+    expect(find.text('Identifier'), findsOneWidget);
+    // OK -> non-error icon.
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+    expect(find.byIcon(Icons.warning_rounded), findsNothing);
+  });
+
+  testWidgets('renders a placeholder before the first reading', (tester) async {
+    await _pump(tester, _summary()); // no state
+
+    expect(find.text('--°C'), findsOneWidget);
+    expect(find.text('Awaiting first reading'), findsOneWidget);
+    expect(find.text('No successful readings yet.'), findsOneWidget);
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+  });
+
+  testWidgets('shows the alert treatment when out of range', (tester) async {
+    await _pump(
+      tester,
+      _summary(
+        status: ThermostatReadingStatus.outOfRange,
+        value: 25.0,
+        message: 'Out of range: 25.00°C (10.00°C – 20.00°C)',
+        fetchedAt: recent,
+      ),
+    );
+
+    expect(find.byIcon(Icons.warning_rounded), findsOneWidget);
+    expect(find.byIcon(Icons.check_circle), findsNothing);
+    expect(find.textContaining('Out of range'), findsWidgets);
+  });
+
+  testWidgets('every error status renders as an alert', (tester) async {
+    for (final status in const [
+      ThermostatReadingStatus.networkError,
+      ThermostatReadingStatus.httpError,
+      ThermostatReadingStatus.parseError,
+      ThermostatReadingStatus.unknown,
+    ]) {
+      await _pump(
+        tester,
+        _summary(status: status, value: 12.0, fetchedAt: recent),
+      );
+      expect(
+        find.byIcon(Icons.warning_rounded),
+        findsOneWidget,
+        reason: '$status should be an alert',
+      );
+    }
+  });
+
+  testWidgets('exposes an accessible semantics label and value', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      _summary(
+        status: ThermostatReadingStatus.ok,
+        value: 15.0,
+        fetchedAt: recent,
+      ),
+      onTap: () {},
+    );
+
+    final semantics = tester.getSemantics(find.byType(ThermostatCard));
+    expect(semantics.label, contains('Thermostat Greenhouse'));
+    expect(semantics.value, contains('degrees Celsius'));
+  });
+
+  testWidgets('invokes the action callbacks', (tester) async {
+    var tapped = 0;
+    var edited = 0;
+    var deleted = 0;
+    var refreshed = 0;
+
+    await _pump(
+      tester,
+      _summary(
+        status: ThermostatReadingStatus.ok,
+        value: 15.0,
+        fetchedAt: recent,
+      ),
+      onTap: () => tapped++,
+      onEdit: () => edited++,
+      onDelete: () => deleted++,
+      onRefresh: () => refreshed++,
+    );
+
+    await tester.tap(find.text('Greenhouse'));
+    expect(tapped, 1);
+
+    await tester.tap(find.byTooltip('Refresh thermostat'));
+    expect(refreshed, 1);
+
+    await tester.tap(find.byTooltip('More actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Edit details'));
+    await tester.pumpAndSettle();
+    expect(edited, 1);
+
+    await tester.tap(find.byTooltip('More actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Delete thermostat'));
+    await tester.pumpAndSettle();
+    expect(deleted, 1);
+  });
+}

--- a/app/test/widget/thermostat_detail_page_test.dart
+++ b/app/test/widget/thermostat_detail_page_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:farmctl/features/thermostats/models/history_range.dart';
+import 'package:farmctl/features/thermostats/models/temperature_sample.dart';
+import 'package:farmctl/features/thermostats/models/thermostat.dart';
+import 'package:farmctl/features/thermostats/models/thermostat_state.dart';
+import 'package:farmctl/features/thermostats/providers/thermostat_providers.dart';
+import 'package:farmctl/features/thermostats/view/thermostat_detail_page.dart';
+import 'package:farmctl/features/thermostats/widgets/thermostat_card.dart';
+import 'package:farmctl/features/thermostats/widgets/thermostat_history_chart.dart';
+
+const _id = 'thermostat-1';
+
+ThermostatSummary _summary() {
+  final timestamp = DateTime.utc(2025, 1, 1, 12);
+  return ThermostatSummary(
+    thermostat: Thermostat(
+      id: _id,
+      name: 'Greenhouse',
+      rawUrl: 'a' * 32,
+      minC: 10,
+      maxC: 20,
+      hysteresisEnabled: false,
+      monitoringEnabled: true,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    ),
+    state: ThermostatState(
+      thermostatId: _id,
+      status: ThermostatReadingStatus.ok,
+      lastValueC: 15.0,
+      lastFetchedAt: timestamp,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    ),
+  );
+}
+
+List<TemperatureSample> _samples() {
+  final base = DateTime.utc(2025, 1, 1, 12);
+  return [
+    for (var i = 0; i < 5; i++)
+      TemperatureSample(
+        id: 's$i',
+        thermostatId: _id,
+        valueC: 14.0 + i,
+        observedAt: base.add(Duration(minutes: 10 * i)),
+        source: 'revision',
+        sourceId: 'rev-$i',
+      ),
+  ];
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required ThermostatSummary? summary,
+  Stream<List<TemperatureSample>>? history,
+}) async {
+  tester.view.physicalSize = const Size(420, 2600);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        thermostatSummaryProvider(
+          _id,
+        ).overrideWith((ref) => Stream.value(summary)),
+        thermostatHistoryProvider((
+          thermostatId: _id,
+          range: ThermostatHistoryRange.day,
+        )).overrideWith((ref) => history ?? Stream.value(_samples())),
+        thermostatHistoryRefreshProvider((
+          thermostatId: _id,
+          prioritizeLastHour: true,
+        )).overrideWith((ref) async {}),
+      ],
+      child: const MaterialApp(home: ThermostatDetailPage(thermostatId: _id)),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('renders the card, history section, chart and range selector', (
+    tester,
+  ) async {
+    await _pump(tester, summary: _summary());
+
+    // App-bar title and the card both show the name.
+    expect(find.text('Greenhouse'), findsWidgets);
+    expect(find.byType(ThermostatCard), findsOneWidget);
+    expect(find.text('History'), findsOneWidget);
+    expect(find.byType(ThermostatHistoryChart), findsOneWidget);
+    // The range selector exposes its labels.
+    expect(find.text('24H'), findsOneWidget);
+    expect(find.text('All'), findsOneWidget);
+  });
+
+  testWidgets('shows a not-found state for a missing thermostat', (
+    tester,
+  ) async {
+    await _pump(tester, summary: null);
+
+    expect(find.text('Thermostat not found.'), findsOneWidget);
+    expect(find.byType(ThermostatCard), findsNothing);
+  });
+
+  testWidgets('shows a history error when the history stream fails', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      summary: _summary(),
+      history: Stream<List<TemperatureSample>>.error(Exception('boom')),
+    );
+
+    expect(find.text('Unable to load history.'), findsOneWidget);
+  });
+}

--- a/app/test/widget/thermostat_form_dialog_test.dart
+++ b/app/test/widget/thermostat_form_dialog_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:farmctl/features/thermostats/data/thermostat_client.dart';
+import 'package:farmctl/features/thermostats/models/thermostat.dart';
+import 'package:farmctl/features/thermostats/models/thermostat_state.dart';
+import 'package:farmctl/features/thermostats/widgets/thermostat_form_dialog.dart';
+
+Thermostat _dummy() {
+  final timestamp = DateTime.utc(2025, 1, 1);
+  return Thermostat(
+    id: 'thermostat-1',
+    name: 'Barn',
+    rawUrl: 'a' * 32,
+    minC: 0,
+    maxC: 20,
+    hysteresisEnabled: false,
+    monitoringEnabled: true,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  );
+}
+
+Future<void> _openDialog(
+  WidgetTester tester, {
+  required Future<Thermostat> Function(ThermostatDraft draft) onSubmit,
+  Thermostat? initial,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => Center(
+            child: TextButton(
+              onPressed: () => showDialog<Thermostat>(
+                context: context,
+                builder: (_) =>
+                    ThermostatFormDialog(onSubmit: onSubmit, initial: initial),
+              ),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+}
+
+Future<void> _fillValid(WidgetTester tester) async {
+  await tester.enterText(find.byType(TextFormField).at(0), 'Barn');
+  await tester.enterText(find.byType(TextFormField).at(1), 'a' * 32);
+  await tester.enterText(find.byType(TextFormField).at(2), '0');
+  await tester.enterText(find.byType(TextFormField).at(3), '20');
+}
+
+void main() {
+  testWidgets('validates required name and gist id on empty submit', (
+    tester,
+  ) async {
+    var called = false;
+    await _openDialog(
+      tester,
+      onSubmit: (_) async {
+        called = true;
+        return _dummy();
+      },
+    );
+
+    await tester.tap(find.text('Test & Save'));
+    await tester.pump();
+
+    expect(find.text('Enter a name.'), findsOneWidget);
+    expect(find.text('Enter a Gist ID.'), findsOneWidget);
+    expect(called, isFalse);
+  });
+
+  testWidgets('flags non-numeric min/max', (tester) async {
+    await _openDialog(tester, onSubmit: (_) async => _dummy());
+    await tester.enterText(find.byType(TextFormField).at(0), 'Barn');
+    await tester.enterText(find.byType(TextFormField).at(1), 'a' * 32);
+    await tester.enterText(find.byType(TextFormField).at(2), 'abc');
+    await tester.enterText(find.byType(TextFormField).at(3), 'xyz');
+
+    await tester.tap(find.text('Test & Save'));
+    await tester.pump();
+
+    expect(find.text('Enter a number.'), findsNWidgets(2));
+  });
+
+  testWidgets('flags an inverted range (min >= max)', (tester) async {
+    await _openDialog(tester, onSubmit: (_) async => _dummy());
+    await tester.enterText(find.byType(TextFormField).at(0), 'Barn');
+    await tester.enterText(find.byType(TextFormField).at(1), 'a' * 32);
+    await tester.enterText(find.byType(TextFormField).at(2), '20');
+    await tester.enterText(find.byType(TextFormField).at(3), '10');
+
+    await tester.tap(find.text('Test & Save'));
+    await tester.pump();
+
+    expect(find.text('Minimum must be less than maximum.'), findsOneWidget);
+  });
+
+  testWidgets('rejects an invalid gist id', (tester) async {
+    await _openDialog(tester, onSubmit: (_) async => _dummy());
+    await tester.enterText(find.byType(TextFormField).at(0), 'Barn');
+    await tester.enterText(find.byType(TextFormField).at(1), 'not-a-gist-id');
+    await tester.enterText(find.byType(TextFormField).at(2), '0');
+    await tester.enterText(find.byType(TextFormField).at(3), '20');
+
+    await tester.tap(find.text('Test & Save'));
+    await tester.pump();
+
+    expect(find.text('Enter a valid GitHub Gist ID.'), findsOneWidget);
+  });
+
+  testWidgets('submits a valid draft and closes', (tester) async {
+    ThermostatDraft? captured;
+    await _openDialog(
+      tester,
+      onSubmit: (draft) async {
+        captured = draft;
+        return _dummy();
+      },
+    );
+    await _fillValid(tester);
+
+    await tester.tap(find.text('Test & Save'));
+    await tester.pumpAndSettle();
+
+    expect(captured, isNotNull);
+    expect(captured!.name, 'Barn');
+    expect(captured!.rawUrl, 'a' * 32);
+    expect(captured!.minC, 0);
+    expect(captured!.maxC, 20);
+    // Dialog closed on success.
+    expect(find.text('Test & Save'), findsNothing);
+  });
+
+  testWidgets('surfaces a fetch error from onSubmit and stays open', (
+    tester,
+  ) async {
+    await _openDialog(
+      tester,
+      onSubmit: (_) async => throw const ThermostatFetchException(
+        status: ThermostatReadingStatus.networkError,
+        message: 'Could not reach the Gist API.',
+      ),
+    );
+    await _fillValid(tester);
+
+    await tester.tap(find.text('Test & Save'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Could not reach the Gist API.'), findsOneWidget);
+    expect(find.text('Test & Save'), findsOneWidget); // still open
+  });
+
+  testWidgets('pre-fills the fields when editing', (tester) async {
+    await _openDialog(
+      tester,
+      onSubmit: (_) async => _dummy(),
+      initial: _dummy(),
+    );
+
+    expect(find.text('Edit thermostat'), findsOneWidget);
+    expect(find.text('Barn'), findsOneWidget);
+    expect(find.text('0.00'), findsOneWidget);
+    expect(find.text('20.00'), findsOneWidget);
+  });
+}

--- a/app/test/widget/thermostat_history_chart_test.dart
+++ b/app/test/widget/thermostat_history_chart_test.dart
@@ -1,0 +1,117 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:farmctl/features/thermostats/models/history_range.dart';
+import 'package:farmctl/features/thermostats/models/temperature_sample.dart';
+import 'package:farmctl/features/thermostats/widgets/thermostat_history_chart.dart';
+
+List<TemperatureSample> _samples(
+  int count, {
+  Duration step = const Duration(minutes: 10),
+}) {
+  final base = DateTime.utc(2025, 1, 1, 12);
+  return [
+    for (var i = 0; i < count; i++)
+      TemperatureSample(
+        id: 's$i',
+        thermostatId: 't1',
+        valueC: 10.0 + i,
+        observedAt: base.add(step * i),
+        source: 'revision',
+        sourceId: 'rev-$i',
+      ),
+  ];
+}
+
+Future<void> _pump(
+  WidgetTester tester,
+  List<TemperatureSample> samples,
+  ThermostatHistoryRange range, {
+  bool expand = false,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: 400,
+          height: 300,
+          child: ThermostatHistoryChart(
+            samples: samples,
+            range: range,
+            expand: expand,
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('shows an empty message when there is no history', (
+    tester,
+  ) async {
+    await _pump(tester, const [], ThermostatHistoryRange.day);
+    expect(
+      find.text('No history available for this range yet.'),
+      findsOneWidget,
+    );
+    expect(find.byType(LineChart), findsNothing);
+  });
+
+  testWidgets('renders a line chart with accessible summary', (tester) async {
+    await _pump(tester, _samples(6), ThermostatHistoryRange.day);
+
+    expect(find.byType(LineChart), findsOneWidget);
+    final semantics = tester.getSemantics(find.byType(ThermostatHistoryChart));
+    expect(semantics.label, contains('Temperature history'));
+    expect(semantics.value, contains('degrees Celsius'));
+  });
+
+  testWidgets('handles a single sample (degenerate x-axis)', (tester) async {
+    await _pump(tester, _samples(1), ThermostatHistoryRange.hour);
+    expect(find.byType(LineChart), findsOneWidget);
+  });
+
+  testWidgets('handles a flat series (zero value span)', (tester) async {
+    final base = DateTime.utc(2025, 1, 1, 12);
+    final flat = [
+      for (var i = 0; i < 4; i++)
+        TemperatureSample(
+          id: 'f$i',
+          thermostatId: 't1',
+          valueC: 18.0,
+          observedAt: base.add(Duration(minutes: 10 * i)),
+          source: 'revision',
+        ),
+    ];
+    await _pump(tester, flat, ThermostatHistoryRange.day);
+    expect(find.byType(LineChart), findsOneWidget);
+  });
+
+  testWidgets('renders for every range (axis formatters)', (tester) async {
+    for (final range in ThermostatHistoryRange.values) {
+      await _pump(tester, _samples(8, step: const Duration(hours: 6)), range);
+      expect(find.byType(LineChart), findsOneWidget);
+    }
+  });
+
+  testWidgets('expands to fill when requested', (tester) async {
+    await _pump(tester, _samples(4), ThermostatHistoryRange.week, expand: true);
+    expect(find.byType(LineChart), findsOneWidget);
+  });
+
+  testWidgets('handles a very wide time span (axis interval fallback)', (
+    tester,
+  ) async {
+    // Months apart -> span exceeds the largest preset interval, exercising the
+    // computed-interval fallback.
+    await _pump(
+      tester,
+      _samples(6, step: const Duration(days: 30)),
+      ThermostatHistoryRange.all,
+    );
+    expect(find.byType(LineChart), findsOneWidget);
+  });
+}

--- a/app/test/widget/thermostat_history_fullscreen_page_test.dart
+++ b/app/test/widget/thermostat_history_fullscreen_page_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:farmctl/features/thermostats/models/history_range.dart';
+import 'package:farmctl/features/thermostats/models/temperature_sample.dart';
+import 'package:farmctl/features/thermostats/models/thermostat.dart';
+import 'package:farmctl/features/thermostats/models/thermostat_state.dart';
+import 'package:farmctl/features/thermostats/providers/thermostat_providers.dart';
+import 'package:farmctl/features/thermostats/view/thermostat_history_fullscreen_page.dart';
+import 'package:farmctl/features/thermostats/widgets/thermostat_history_chart.dart';
+
+const _id = 'thermostat-1';
+
+ThermostatSummary _summary() {
+  final timestamp = DateTime.utc(2025, 1, 1, 12);
+  return ThermostatSummary(
+    thermostat: Thermostat(
+      id: _id,
+      name: 'Greenhouse',
+      rawUrl: 'a' * 32,
+      minC: 10,
+      maxC: 20,
+      hysteresisEnabled: false,
+      monitoringEnabled: true,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    ),
+    state: ThermostatState(
+      thermostatId: _id,
+      status: ThermostatReadingStatus.ok,
+      lastValueC: 15.0,
+      lastFetchedAt: timestamp,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    ),
+  );
+}
+
+List<TemperatureSample> _samples() {
+  final base = DateTime.utc(2025, 1, 1, 12);
+  return [
+    for (var i = 0; i < 5; i++)
+      TemperatureSample(
+        id: 's$i',
+        thermostatId: _id,
+        valueC: 14.0 + i,
+        observedAt: base.add(Duration(minutes: 10 * i)),
+        source: 'revision',
+        sourceId: 'rev-$i',
+      ),
+  ];
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required ThermostatSummary? summary,
+  ThermostatHistoryRange range = ThermostatHistoryRange.day,
+}) async {
+  // Landscape surface so the in-app-bar range dropdown branch is exercised.
+  tester.view.physicalSize = const Size(900, 480);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        thermostatSummaryProvider(
+          _id,
+        ).overrideWith((ref) => Stream.value(summary)),
+        thermostatHistoryProvider((
+          thermostatId: _id,
+          range: range,
+        )).overrideWith((ref) => Stream.value(_samples())),
+        thermostatHistoryRefreshProvider((
+          thermostatId: _id,
+          prioritizeLastHour: true,
+        )).overrideWith((ref) async {}),
+      ],
+      child: MaterialApp(
+        home: ThermostatHistoryFullscreenPage(
+          thermostatId: _id,
+          initialRange: range,
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('renders the chart with the named title and close button', (
+    tester,
+  ) async {
+    await _pump(tester, summary: _summary());
+
+    expect(find.text('Greenhouse history'), findsOneWidget);
+    expect(find.byType(ThermostatHistoryChart), findsOneWidget);
+    expect(find.byTooltip('Close full-screen chart'), findsOneWidget);
+  });
+
+  testWidgets('falls back to a generic title when the name is unknown', (
+    tester,
+  ) async {
+    await _pump(tester, summary: null);
+
+    expect(find.text('Thermostat history'), findsOneWidget);
+    expect(find.byType(ThermostatHistoryChart), findsOneWidget);
+  });
+
+  testWidgets('exposes the range dropdown in landscape', (tester) async {
+    await _pump(tester, summary: _summary());
+
+    expect(
+      find.byWidgetPredicate(
+        (widget) => widget is DropdownButton<ThermostatHistoryRange>,
+      ),
+      findsOneWidget,
+    );
+  });
+}

--- a/app/test/widget/thermostats_page_test.dart
+++ b/app/test/widget/thermostats_page_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:farmctl/features/thermostats/models/thermostat.dart';
+import 'package:farmctl/features/thermostats/models/thermostat_state.dart';
+import 'package:farmctl/features/thermostats/providers/thermostat_providers.dart';
+import 'package:farmctl/features/thermostats/view/thermostats_page.dart';
+import 'package:farmctl/features/thermostats/widgets/thermostat_card.dart';
+
+ThermostatSummary _summary(String id, String name) {
+  final timestamp = DateTime.utc(2025, 1, 1, 12);
+  return ThermostatSummary(
+    thermostat: Thermostat(
+      id: id,
+      name: name,
+      rawUrl: 'a' * 32,
+      minC: 10,
+      maxC: 20,
+      hysteresisEnabled: false,
+      monitoringEnabled: true,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    ),
+    state: ThermostatState(
+      thermostatId: id,
+      status: ThermostatReadingStatus.ok,
+      lastValueC: 15.0,
+      lastFetchedAt: timestamp,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    ),
+  );
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required Stream<List<ThermostatSummary>> thermostats,
+  OfflineStatus offline = OfflineStatus.online,
+}) async {
+  // Narrow, tall surface so the layout uses the single-column scrolling list
+  // (the wide multi-column grid constrains card height and overflows in tests).
+  tester.view.physicalSize = const Size(420, 1600);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        thermostatsProvider.overrideWith((ref) => thermostats),
+        // Override so the provider's periodic re-eval timer isn't started.
+        offlineStatusProvider.overrideWithValue(offline),
+      ],
+      child: const MaterialApp(home: ThermostatsPage()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('shows the empty state with an add affordance', (tester) async {
+    await _pump(tester, thermostats: Stream.value(const <ThermostatSummary>[]));
+
+    expect(find.text('No thermostats yet'), findsOneWidget);
+    expect(find.text('Add thermostat'), findsOneWidget);
+    expect(find.byType(ThermostatCard), findsNothing);
+  });
+
+  testWidgets('renders a card per thermostat', (tester) async {
+    await _pump(
+      tester,
+      thermostats: Stream.value([
+        _summary('t1', 'Greenhouse'),
+        _summary('t2', 'Barn'),
+      ]),
+    );
+
+    expect(find.byType(ThermostatCard), findsNWidgets(2));
+    expect(find.text('Greenhouse'), findsOneWidget);
+    expect(find.text('Barn'), findsOneWidget);
+  });
+
+  testWidgets('shows an error state when the stream errors', (tester) async {
+    await _pump(
+      tester,
+      thermostats: Stream<List<ThermostatSummary>>.error(
+        Exception('database down'),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Failed to load thermostats.'), findsOneWidget);
+  });
+
+  testWidgets('shows the offline banner when offline', (tester) async {
+    await _pump(
+      tester,
+      thermostats: Stream.value([_summary('t1', 'Greenhouse')]),
+      offline: OfflineStatus.offline,
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.text('Offline mode'), findsOneWidget);
+  });
+
+  testWidgets('shows the degraded banner when connectivity is degraded', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      thermostats: Stream.value([_summary('t1', 'Greenhouse')]),
+      offline: OfflineStatus.degraded,
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.text('Connectivity issues'), findsOneWidget);
+  });
+
+  testWidgets('hides the banner when online', (tester) async {
+    await _pump(
+      tester,
+      thermostats: Stream.value([_summary('t1', 'Greenhouse')]),
+      offline: OfflineStatus.online,
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.text('Offline mode'), findsNothing);
+    expect(find.text('Connectivity issues'), findsNothing);
+  });
+}

--- a/tool/check_coverage.sh
+++ b/tool/check_coverage.sh
@@ -11,8 +11,15 @@ if [ ! -f "$LCOV" ]; then
   exit 1
 fi
 
-hit=$(awk -F: '/^LH:/ {s+=$2} END {print s+0}' "$LCOV")
-found=$(awk -F: '/^LF:/ {s+=$2} END {print s+0}' "$LCOV")
+# Exclude generated sources (*.g.dart, *.freezed.dart) — they are not
+# hand-written and testing them is meaningless, so they shouldn't dilute the
+# coverage metric.
+read -r hit found < <(awk -F: '
+  /^SF:/ { gen = ($0 ~ /\.g\.dart$/ || $0 ~ /\.freezed\.dart$/) }
+  /^LH:/ { if (!gen) h += $2 }
+  /^LF:/ { if (!gen) f += $2 }
+  END { print h+0, f+0 }
+' "$LCOV")
 
 if [ "$found" -eq 0 ]; then
   echo "::error::no lines found in coverage report"


### PR DESCRIPTION
Three pieces of work (the latter two were requested follow-ups).

## 1. Verify active monitoring (polling intervals + alarm triggering)
Audited the pipeline end to end — it's correct (next run = `now + pollInterval`; WorkManager ≥15-min floor; 10s debounce; pause defers; range-check → atomic CAS → rate-limit/snooze/silence). Extracted the cadence logic into testable `nextMonitorRunUtc`/`effectiveMonitorFrequency` and tested it; added a monitoring-disabled-thermostat test; and fixed a gap where a config-load failure dropped sub-15-min polling to the WorkManager floor.

## 2. Independent audit of the previously-unreviewed changes
Ran an adversarial 3-reviewer + validator pass over everything that shipped without an independent review (round-2/3 bug fixes + the monitoring work). Verdict: fundamentally sound, no critical regression. Fixed the 4 real defects it found:
- **HIGH** — the Settings "test alarm" re-init nulled the foreground notification-tap handler; `_initializeNotifications` now defaults it so it can't be cleared.
- **MEDIUM** — `_saveTestedState` didn't clear silence/snooze on an OK reading (could mute a future real alarm); now mirrors `refresh()`.
- **MEDIUM** — a v7→v8 migration now consolidates pre-existing duplicate `alert_config` rows.
- **LOW** — the token-test Dio client is closed in a `finally`.

## 3. Coverage 47.8% → 60.2%
Excluded generated Drift code from the metric (it shouldn't be tested), then covered the largest real units with behaviour-asserting tests: the history chart, thermostats list page, detail + fullscreen pages, alarm page states, the offline-status provider, the HTTP client, and several model/repository methods. CI floor ratcheted **31% → 60%**.

## Quality
App tests 114 → **167**; parsing 100%; both gates pass; analyze/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)