### PR TITLE
Comprehensive UX overhaul

### DIFF
--- a/.agent/ExecPlan-UXOverhaul.md
+++ b/.agent/ExecPlan-UXOverhaul.md
@@ -1,0 +1,41 @@
+# ExecPlan — UX Overhaul (fix/ux-overhaul)
+
+Fixes the full set of findings from the 2026-06-28 comprehensive UX review.
+User decisions: fix **everything**; alarm "Dismiss" → **Acknowledge (stay armed)**;
+**leave the Gist-ID field as-is**; delete → **Undo + error-tint**.
+
+## Shared helpers (Iter A)
+- `core/format/semantics_text.dart` — `spokenTemperature` / normalize `°C`→"degrees Celsius", `•`→".".
+- `core/format/error_messages.dart` — `humanizeError(Object)` → friendly, actionable copy (no raw exception dumps).
+- `core/format/relative_time.dart` — shared `formatRelativeDuration` + `formatElapsed` (promote from card).
+- `features/thermostats/models/thermostat_status_presentation.dart` — map each of the 6 `ThermostatReadingStatus`
+  to (label word, icon, severity: ok|warning|danger|offline) so status is never color-only and out-of-range ≠ wifi blip.
+
+## Iterations
+- **B Alarm screen** — Semantics + `liveRegion` + announce on appear; `Acknowledge` replaces `Dismiss`
+  (stops sound, stays armed, no permanent silence); full-width ≥56dp stacked actions ordered by escalation;
+  elapsed "out of range for …" from `lastAlarmAt`; `SingleChildScrollView`; clamp name; spoken °C;
+  announce snooze/silence outcome; "Silence until back in range"; humanized error.
+- **C Card** — distinct icon+colour+word per status via presentation model; hero highlight driven by
+  out-of-range (temperature) not connectivity; explicit status pill; staleness dim past threshold;
+  `explicitChildNodes`; de-dup spoken temperature.
+- **D Thermostats page** — pull-to-refresh + Retry on error; delete Undo (re-create) + error-tinted Delete;
+  app-wide Pause banner w/ Resume; empty-state inline CTA; offline banner uses tertiary/error (not green)
+  + distinguishes offline/degraded + `liveRegion`; humanized + consistently-styled snackbars; in-flight guard.
+- **E Detail / fullscreen / chart** — not-found hides Refresh + adds "Back to thermostats"; shared range state
+  across detail↔fullscreen; inline history Retry + drop duplicate indicator; no forced orientation;
+  chart min/max safe-range band; Y-axis 1-dp + °C; explicit tooltip colour; consistent state heights.
+- **F Settings** — persistent sub-15-min cadence note (honest freshness); poll-commit + test-alarm confirmations;
+  token "optional/leave blank" + humanized test result + how-to + in-flight + unsaved hint; pause absolute time;
+  `_formatDuration` one style; copy polish; slider semantics.
+- **G Form dialog** — Min/Max inline validators + hints + range error on Max field; "Save without testing" on
+  network failure + "Testing connection…"; strip trailing `.00`; `maxLength: 40`; spoken field labels. (Gist field untouched.)
+- **H Router** — branded `errorBuilder` 404 w/ "Go to Thermostats"; delete dead `pathFor` helpers.
+- **I Tests** — update tests the new behaviour breaks; add tests for new logic; keep ≥70% (gen + Drift decls excluded); analyze/format green.
+- **J Reviews** — 2 review agents (correctness/logic + a11y/safety) + validator; fix real findings.
+- **K PR**.
+
+## Guardrails
+- `dart run build_runner build --delete-conflicting-outputs` before analyze/test.
+- No production-behaviour change to alarm *arming* — Acknowledge must still allow re-alert.
+- Keep diffs focused; Material 3 via Theme/ColorScheme only.

--- a/app/lib/core/format/error_messages.dart
+++ b/app/lib/core/format/error_messages.dart
@@ -1,0 +1,44 @@
+/// Maps an arbitrary thrown object to a short, friendly, actionable message
+/// suitable for end users. Raw exception/stack text (Dio, Drift, sockets) is
+/// noise to a non-technical user and can leak internal detail, so error
+/// surfaces should route through this instead of interpolating `'$error'`.
+String humanizeError(Object? error) {
+  if (error == null) {
+    return 'Something went wrong. Please try again.';
+  }
+  final text = error.toString().toLowerCase();
+
+  bool has(String needle) => text.contains(needle);
+
+  if (has('timeout') || has('timed out')) {
+    return 'The request timed out. Check your connection and try again.';
+  }
+  if (has('socket') ||
+      has('connection') ||
+      has('network') ||
+      has('host lookup') ||
+      has('unreachable') ||
+      has('failed host')) {
+    return "Couldn't reach the server. Check your connection and try again.";
+  }
+  if (has('401') ||
+      has('403') ||
+      has('unauthor') ||
+      has('forbidden') ||
+      has('credential')) {
+    return 'Access was refused. Check your GitHub token in Settings.';
+  }
+  if (has('429') || has('rate limit')) {
+    return 'Rate limit reached. Add a GitHub token in Settings or try again later.';
+  }
+  if (has('404') || has('not found')) {
+    return "The data source couldn't be found. Check the sensor configuration.";
+  }
+  if (has('500') || has('502') || has('503') || has('server error')) {
+    return 'The server had a problem. Please try again shortly.';
+  }
+  if (has('format') || has('parse') || has('unexpected') || has('invalid')) {
+    return "The reading couldn't be read — the sensor may be reporting an unexpected format.";
+  }
+  return 'Something went wrong. Please try again.';
+}

--- a/app/lib/core/format/error_messages.dart
+++ b/app/lib/core/format/error_messages.dart
@@ -13,19 +13,14 @@ String humanizeError(Object? error) {
   if (has('timeout') || has('timed out')) {
     return 'The request timed out. Check your connection and try again.';
   }
-  if (has('socket') ||
-      has('connection') ||
-      has('network') ||
-      has('host lookup') ||
-      has('unreachable') ||
-      has('failed host')) {
-    return "Couldn't reach the server. Check your connection and try again.";
-  }
+  // Auth/rate-limit/status codes are checked before the broad connectivity
+  // needles so an HTTP error that merely echoes a "Connection:" header isn't
+  // mis-reported as offline.
   if (has('401') ||
       has('403') ||
       has('unauthor') ||
       has('forbidden') ||
-      has('credential')) {
+      has('bad credential')) {
     return 'Access was refused. Check your GitHub token in Settings.';
   }
   if (has('429') || has('rate limit')) {
@@ -37,7 +32,17 @@ String humanizeError(Object? error) {
   if (has('500') || has('502') || has('503') || has('server error')) {
     return 'The server had a problem. Please try again shortly.';
   }
-  if (has('format') || has('parse') || has('unexpected') || has('invalid')) {
+  if (has('socketexception') ||
+      has('connection refused') ||
+      has('connection closed') ||
+      has('connection error') ||
+      has('network') ||
+      has('host lookup') ||
+      has('unreachable') ||
+      has('failed host')) {
+    return "Couldn't reach the server. Check your connection and try again.";
+  }
+  if (has('formatexception') || has('parse') || has('unexpected format')) {
     return "The reading couldn't be read — the sensor may be reporting an unexpected format.";
   }
   return 'Something went wrong. Please try again.';

--- a/app/lib/core/format/relative_time.dart
+++ b/app/lib/core/format/relative_time.dart
@@ -1,0 +1,45 @@
+/// Formats a duration as a relative "… ago" phrase for last-seen timestamps.
+String formatRelativeDuration(Duration difference) {
+  final seconds = difference.inSeconds.abs();
+  if (seconds < 60) {
+    return 'just now';
+  }
+  final minutes = difference.inMinutes;
+  if (minutes.abs() < 60) {
+    final value = minutes.abs();
+    final unit = value == 1 ? 'min' : 'mins';
+    return '$value $unit ago';
+  }
+  final hours = difference.inHours;
+  if (hours.abs() < 24) {
+    final value = hours.abs();
+    final unit = value == 1 ? 'hour' : 'hours';
+    return '$value $unit ago';
+  }
+  final days = difference.inDays;
+  final unit = days.abs() == 1 ? 'day' : 'days';
+  return '${days.abs()} $unit ago';
+}
+
+/// Formats a duration as an elapsed span ("2 hours 14 min") without the "ago"
+/// suffix — used to convey how long an alarm condition has persisted.
+String formatElapsed(Duration duration) {
+  final totalSeconds = duration.inSeconds.abs();
+  if (totalSeconds < 60) {
+    return 'less than a minute';
+  }
+  final totalMinutes = duration.inMinutes.abs();
+  if (totalMinutes < 60) {
+    return '$totalMinutes ${totalMinutes == 1 ? 'minute' : 'minutes'}';
+  }
+  final totalHours = duration.inHours.abs();
+  if (totalHours < 24) {
+    final mins = totalMinutes - totalHours * 60;
+    final hourPart = '$totalHours ${totalHours == 1 ? 'hour' : 'hours'}';
+    return mins == 0 ? hourPart : '$hourPart $mins min';
+  }
+  final totalDays = duration.inDays.abs();
+  final hours = totalHours - totalDays * 24;
+  final dayPart = '$totalDays ${totalDays == 1 ? 'day' : 'days'}';
+  return hours == 0 ? dayPart : '$dayPart $hours h';
+}

--- a/app/lib/core/format/semantics_text.dart
+++ b/app/lib/core/format/semantics_text.dart
@@ -1,0 +1,12 @@
+/// Rewrites compact on-screen strings into something a screen reader speaks
+/// correctly — e.g. `21.5°C` becomes "21.5 degrees Celsius" and the `•`
+/// separator becomes a sentence break rather than "bullet".
+String spokenText(String input) {
+  return input
+      .replaceAll('°C', ' degrees Celsius')
+      .replaceAll('°', ' degrees')
+      .replaceAll('•', '.')
+      .replaceAll('–', 'to')
+      .replaceAll('  ', ' ')
+      .trim();
+}

--- a/app/lib/core/router/app_router.dart
+++ b/app/lib/core/router/app_router.dart
@@ -14,6 +14,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
   return GoRouter(
     navigatorKey: rootNavigatorKey,
     initialLocation: ThermostatsRoute.path,
+    errorBuilder: (context, state) => const _RouteNotFoundPage(),
     routes: [
       GoRoute(
         path: AlarmRoute.path,
@@ -141,16 +142,11 @@ class ThermostatsRoute {
 class ThermostatDetailRoute {
   static const name = 'thermostat-detail';
   static const path = 'detail/:id';
-
-  static String pathFor(String thermostatId) => 'detail/$thermostatId';
 }
 
 class ThermostatHistoryFullscreenRoute {
   static const name = 'thermostat-history-fullscreen';
   static const path = 'history';
-
-  static String pathFor(String thermostatId) =>
-      '${ThermostatDetailRoute.pathFor(thermostatId)}/$path';
 }
 
 class SettingsRoute {
@@ -163,4 +159,52 @@ class AlarmRoute {
   static const path = '/alarm/:id';
 
   static String pathFor(String thermostatId) => '/alarm/$thermostatId';
+}
+
+/// Branded fallback for an unknown or malformed deep link (e.g. a stale
+/// notification payload) so the user lands somewhere recoverable.
+class _RouteNotFoundPage extends StatelessWidget {
+  const _RouteNotFoundPage();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Page not found')),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.help_outline,
+                size: 48,
+                color: theme.colorScheme.primary,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                "This screen isn't available",
+                style: theme.textTheme.titleMedium,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'The link may be outdated or the item was removed.',
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 20),
+              FilledButton.icon(
+                onPressed: () => context.goNamed(ThermostatsRoute.name),
+                icon: const Icon(Icons.home_outlined),
+                label: const Text('Go to Thermostats'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/app/lib/features/settings/view/settings_page.dart
+++ b/app/lib/features/settings/view/settings_page.dart
@@ -8,6 +8,7 @@ import 'package:intl/intl.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import '../../../core/background/thermostat_monitor.dart';
+import '../../../core/format/error_messages.dart';
 import '../models/alert_config.dart';
 import '../providers/settings_providers.dart';
 import '../services/sound_picker.dart';
@@ -88,24 +89,27 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
       await initializeBackgroundMonitoring(
         pollFrequency: Duration(minutes: minutes),
       );
+      if (!mounted) return;
       final config = ref.read(alertConfigProvider).asData?.value;
-      if (config != null &&
+      final delayed =
+          config != null &&
           !config.exactAlarmsEnabled &&
-          minutes < _workManagerFloorMinutes &&
-          mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text(
-              'Intervals under 15 minutes may be delayed unless exact alarms are allowed.',
-            ),
+          minutes < _workManagerFloorMinutes;
+      final suffix = delayed
+          ? ' (about every 15 min without exact alarms)'
+          : '';
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            'Checking every $minutes minute${minutes == 1 ? '' : 's'}$suffix',
           ),
-        );
-      }
+        ),
+      );
     } catch (error) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to update poll interval: $error')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(humanizeError(error))));
     } finally {
       if (mounted) {
         setState(() {
@@ -147,9 +151,9 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
       );
     } catch (error) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to update exact alarms: $error')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(humanizeError(error))));
     }
   }
 
@@ -235,9 +239,9 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
       await ref.read(alertConfigRepositoryProvider).setVibrate(value);
     } catch (error) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to update vibrate setting: $error')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(humanizeError(error))));
     }
   }
 
@@ -246,9 +250,9 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
       await ref.read(alertConfigRepositoryProvider).setVolumeBoost(value);
     } catch (error) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to update volume boost: $error')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(humanizeError(error))));
     }
   }
 
@@ -257,15 +261,17 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
       await ref.read(alertConfigRepositoryProvider).pauseFor(duration);
       await initializeBackgroundMonitoring();
       if (!mounted) return;
-      final formatted = _formatDuration(duration);
+      final resumeTime = MaterialLocalizations.of(
+        context,
+      ).formatTimeOfDay(TimeOfDay.fromDateTime(DateTime.now().add(duration)));
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Monitoring paused for $formatted')),
+        SnackBar(content: Text('Monitoring paused until $resumeTime')),
       );
     } catch (error) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to pause monitoring: $error')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(humanizeError(error))));
     }
   }
 
@@ -279,9 +285,9 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
       ).showSnackBar(const SnackBar(content: Text('Monitoring resumed')));
     } catch (error) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to resume monitoring: $error')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(humanizeError(error))));
     }
   }
 
@@ -356,7 +362,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
       if (!mounted) return;
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(SnackBar(content: Text('Failed to update sound: $error')));
+      ).showSnackBar(SnackBar(content: Text(humanizeError(error))));
     }
   }
 
@@ -388,18 +394,24 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
       if (!mounted) return;
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(SnackBar(content: Text('Failed to update sound: $error')));
+      ).showSnackBar(SnackBar(content: Text(humanizeError(error))));
     }
   }
 
   Future<void> _testAlarm(AlertConfig config) async {
     try {
       await showTestAlarmNotification(config: config);
-    } catch (error) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to trigger test alarm: $error')),
+        const SnackBar(
+          content: Text('Test alarm sent — check your notifications'),
+        ),
       );
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(humanizeError(error))));
     }
   }
 
@@ -414,7 +426,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
       if (!mounted) return;
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(SnackBar(content: Text('Failed to export logs: $error')));
+      ).showSnackBar(SnackBar(content: Text(humanizeError(error))));
     }
   }
 
@@ -433,13 +445,17 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
       );
     } catch (error) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to save GitHub token: $error')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(humanizeError(error))));
     }
   }
 
   Future<void> _testGithubToken() async {
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.showSnackBar(
+      const SnackBar(content: Text('Testing GitHub token…')),
+    );
     try {
       final config = await ref.read(alertConfigRepositoryProvider).loadConfig();
       final client = ThermostatHttpClient(githubToken: config.githubToken);
@@ -450,14 +466,14 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
         client.close();
       }
       if (!mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(message)));
+      messenger
+        ..hideCurrentSnackBar()
+        ..showSnackBar(SnackBar(content: Text(message)));
     } catch (error) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to test GitHub token: $error')),
-      );
+      messenger
+        ..hideCurrentSnackBar()
+        ..showSnackBar(SnackBar(content: Text(humanizeError(error))));
     }
   }
 }
@@ -574,6 +590,8 @@ class _SettingsContentState extends State<_SettingsContent> {
                     divisions: 29,
                     value: sliderValue,
                     label: '${sliderValue.round()} min',
+                    semanticFormatterCallback: (value) =>
+                        '${value.round()} minutes',
                     onChanged: widget.onPollIntervalChanged,
                     onChangeEnd: widget.onPollIntervalChangeEnd,
                   ),
@@ -581,6 +599,30 @@ class _SettingsContentState extends State<_SettingsContent> {
                     '${sliderValue.round()} minute${sliderValue.round() == 1 ? '' : 's'}',
                     style: theme.textTheme.bodySmall,
                   ),
+                  if (sliderValue.round() < 15 &&
+                      !widget.config.exactAlarmsEnabled) ...[
+                    const SizedBox(height: 6),
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Icon(
+                          Icons.info_outline,
+                          size: 16,
+                          color: theme.colorScheme.tertiary,
+                        ),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            'Without exact alarms, checks actually run about '
+                            'every 15 minutes.',
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.tertiary,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
                   const SizedBox(height: 20),
                   const Divider(),
                   const SizedBox(height: 20),
@@ -595,7 +637,7 @@ class _SettingsContentState extends State<_SettingsContent> {
                     onChanged: widget.onExactAlarmsChanged,
                     title: const Text('Allow exact alarms'),
                     subtitle: const Text(
-                      'FarmCtl may request the schedule exact alarm permission.',
+                      'Lets FarmCtl ask for permission to schedule precise alarms.',
                     ),
                     contentPadding: EdgeInsets.zero,
                     secondary: const Icon(Icons.alarm_on),
@@ -723,7 +765,9 @@ class _SettingsContentState extends State<_SettingsContent> {
                   const _SettingsTileHeader(
                     title: 'GitHub personal access token',
                     subtitle:
-                        'Optional token to increase API rate limits (60 → 5,000 requests/hour).',
+                        'Optional — most setups work without one. Add a token '
+                        'only if monitoring fails with rate-limit errors; it '
+                        'raises the GitHub limit from 60 to 5,000 requests/hour.',
                   ),
                   const SizedBox(height: 16),
                   TextField(
@@ -767,7 +811,9 @@ class _SettingsContentState extends State<_SettingsContent> {
                   ),
                   const SizedBox(height: 12),
                   Text(
-                    'Stored securely on-device and used only for GitHub API requests.',
+                    'Stored securely on-device and used only for GitHub API '
+                    'requests. Press Save to apply changes. Create a token at '
+                    'github.com/settings/tokens (no scopes required).',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
                       color: Theme.of(context).colorScheme.onSurfaceVariant,
                     ),
@@ -992,15 +1038,15 @@ class _ErrorContent extends StatelessWidget {
 String _formatDuration(Duration duration) {
   final hours = duration.inHours;
   final minutes = duration.inMinutes.remainder(60);
-  if (hours > 0 && minutes > 0) {
-    return '$hours h $minutes m';
-  }
+  final parts = <String>[];
   if (hours > 0) {
-    return '$hours hour${hours == 1 ? '' : 's'}';
+    parts.add('$hours hour${hours == 1 ? '' : 's'}');
   }
-  final mins = duration.inMinutes;
-  if (mins >= 1) {
-    return '$mins minute${mins == 1 ? '' : 's'}';
+  if (minutes > 0) {
+    parts.add('$minutes minute${minutes == 1 ? '' : 's'}');
+  }
+  if (parts.isNotEmpty) {
+    return parts.join(' ');
   }
   final seconds = duration.inSeconds;
   return '$seconds second${seconds == 1 ? '' : 's'}';

--- a/app/lib/features/thermostats/data/thermostat_repository.dart
+++ b/app/lib/features/thermostats/data/thermostat_repository.dart
@@ -118,6 +118,24 @@ class ThermostatRepository {
     });
   }
 
+  /// Re-inserts a previously deleted thermostat with its original identity so a
+  /// delete can be undone. Reading history and last state are not restored.
+  Future<void> restore(Thermostat thermostat) async {
+    await _database.upsertThermostat(
+      ThermostatEntriesCompanion(
+        id: drift.Value(thermostat.id),
+        name: drift.Value(thermostat.name),
+        rawUrl: drift.Value(thermostat.rawUrl),
+        minC: drift.Value(thermostat.minC),
+        maxC: drift.Value(thermostat.maxC),
+        hysteresisEnabled: drift.Value(thermostat.hysteresisEnabled),
+        monitoringEnabled: drift.Value(thermostat.monitoringEnabled),
+        createdAt: drift.Value(thermostat.createdAt),
+        updatedAt: drift.Value(DateTime.now().toUtc()),
+      ),
+    );
+  }
+
   Future<ThermostatState?> loadState(String id) async {
     final entry = await _database.getThermostatState(id);
     if (entry == null) {

--- a/app/lib/features/thermostats/models/thermostat_status_presentation.dart
+++ b/app/lib/features/thermostats/models/thermostat_status_presentation.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/format/relative_time.dart';
+import 'thermostat_state.dart';
+
+/// Severity buckets that drive distinct, non-color-only visuals so an
+/// out-of-range temperature (a real alarm) is never confused with a transient
+/// connectivity problem.
+enum ThermostatStatusSeverity {
+  /// Neutral / awaiting first reading — no judgement yet.
+  neutral,
+
+  /// Reading is good and within the configured range.
+  ok,
+
+  /// Something needs attention but the temperature itself isn't the problem
+  /// (server/parse/unknown errors).
+  warning,
+
+  /// We couldn't reach the sensor; the shown value is last-known-good.
+  offline,
+
+  /// The temperature is out of the safe range — the headline alarm condition.
+  danger,
+}
+
+/// A self-describing presentation for a thermostat's current status: a short
+/// label word, a distinct icon, a severity, and a longer detail sentence.
+/// Each severity maps to its own icon + color so status survives grayscale and
+/// color-blind viewing.
+class ThermostatStatusPresentation {
+  const ThermostatStatusPresentation({
+    required this.label,
+    required this.detail,
+    required this.icon,
+    required this.severity,
+  });
+
+  /// Short status word for a pill/badge, e.g. "In range", "Out of range".
+  final String label;
+
+  /// Longer human sentence with context (value, last-checked time).
+  final String detail;
+
+  final IconData icon;
+  final ThermostatStatusSeverity severity;
+
+  /// True when the *temperature itself* is the problem (drives the loud red
+  /// hero styling). Connectivity issues are deliberately excluded.
+  bool get isDanger => severity == ThermostatStatusSeverity.danger;
+
+  /// True for any non-ok, non-neutral state (drives the warning/alert glyph).
+  bool get isProblem =>
+      severity == ThermostatStatusSeverity.danger ||
+      severity == ThermostatStatusSeverity.warning ||
+      severity == ThermostatStatusSeverity.offline;
+
+  /// Foreground color for this severity, sourced from the theme so dark mode
+  /// stays correct.
+  Color color(ColorScheme scheme) {
+    switch (severity) {
+      case ThermostatStatusSeverity.neutral:
+        return scheme.onSurfaceVariant;
+      case ThermostatStatusSeverity.ok:
+        return scheme.primary;
+      case ThermostatStatusSeverity.warning:
+        return scheme.tertiary;
+      case ThermostatStatusSeverity.offline:
+        return scheme.onSurfaceVariant;
+      case ThermostatStatusSeverity.danger:
+        return scheme.error;
+    }
+  }
+
+  static ThermostatStatusPresentation fromState(
+    ThermostatState? state, {
+    DateTime? now,
+  }) {
+    if (state == null || state.lastFetchedAt == null) {
+      return const ThermostatStatusPresentation(
+        label: 'Awaiting',
+        detail: 'No successful readings yet.',
+        icon: Icons.hourglass_empty,
+        severity: ThermostatStatusSeverity.neutral,
+      );
+    }
+
+    final fetchedAt = state.lastFetchedAt!;
+    final value = state.lastValueC;
+    final message = state.statusMessage;
+    final reference = now ?? DateTime.now().toUtc();
+    final relative = formatRelativeDuration(reference.difference(fetchedAt));
+
+    switch (state.status) {
+      case ThermostatReadingStatus.ok:
+        final base = value != null
+            ? '${value.toStringAsFixed(2)}°C • Updated $relative'
+            : 'Updated $relative';
+        final detail = message != null && message.isNotEmpty
+            ? '$message • Updated $relative'
+            : base;
+        return ThermostatStatusPresentation(
+          label: 'In range',
+          detail: detail,
+          icon: Icons.check_circle,
+          severity: ThermostatStatusSeverity.ok,
+        );
+      case ThermostatReadingStatus.outOfRange:
+        final base = (message != null && message.isNotEmpty)
+            ? message
+            : 'Temperature outside configured range';
+        final detail = value != null
+            ? '$base (${value.toStringAsFixed(2)}°C) • Updated $relative'
+            : '$base • Updated $relative';
+        return ThermostatStatusPresentation(
+          label: 'Out of range',
+          detail: detail,
+          icon: Icons.warning_amber_rounded,
+          severity: ThermostatStatusSeverity.danger,
+        );
+      case ThermostatReadingStatus.networkError:
+        final base = (message != null && message.isNotEmpty)
+            ? message
+            : 'Last attempt failed: network error';
+        return ThermostatStatusPresentation(
+          label: 'Offline',
+          detail: '$base • Checked $relative',
+          icon: Icons.cloud_off,
+          severity: ThermostatStatusSeverity.offline,
+        );
+      case ThermostatReadingStatus.httpError:
+        final base = (message != null && message.isNotEmpty)
+            ? message
+            : 'Last attempt failed: server error';
+        return ThermostatStatusPresentation(
+          label: 'Server error',
+          detail: '$base • Checked $relative',
+          icon: Icons.error_outline,
+          severity: ThermostatStatusSeverity.warning,
+        );
+      case ThermostatReadingStatus.parseError:
+        final base = (message != null && message.isNotEmpty)
+            ? message
+            : 'Last attempt failed: invalid payload';
+        return ThermostatStatusPresentation(
+          label: 'Bad data',
+          detail: '$base • Checked $relative',
+          icon: Icons.error_outline,
+          severity: ThermostatStatusSeverity.warning,
+        );
+      case ThermostatReadingStatus.unknown:
+        final detail = (message != null && message.isNotEmpty)
+            ? '$message • Checked $relative'
+            : 'Last seen $relative';
+        return ThermostatStatusPresentation(
+          label: 'Unknown',
+          detail: detail,
+          icon: Icons.help_outline,
+          severity: ThermostatStatusSeverity.warning,
+        );
+    }
+  }
+}

--- a/app/lib/features/thermostats/providers/thermostat_providers.dart
+++ b/app/lib/features/thermostats/providers/thermostat_providers.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 
 import '../data/thermostat_client.dart';
 import '../data/thermostat_database.dart';
@@ -62,6 +63,13 @@ final thermostatSummaryProvider =
       final repository = ref.watch(thermostatRepositoryProvider);
       return repository.watchThermostat(thermostatId);
     });
+
+/// The history time-range currently selected for a thermostat. Shared so the
+/// detail page and the full-screen chart stay in sync in both directions.
+final selectedHistoryRangeProvider =
+    StateProvider.family<ThermostatHistoryRange, String>(
+      (ref, thermostatId) => ThermostatHistoryRange.day,
+    );
 
 final thermostatHistoryProvider =
     StreamProvider.family<

--- a/app/lib/features/thermostats/view/alarm_fullscreen_page.dart
+++ b/app/lib/features/thermostats/view/alarm_fullscreen_page.dart
@@ -179,11 +179,12 @@ class _AlarmContentState extends ConsumerState<_AlarmContent> {
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
                     const SizedBox(height: 24),
+                    // Decorative — the danger is already in the live-region
+                    // label above, so don't announce "Warning" separately.
                     Icon(
                       Icons.warning_amber_rounded,
                       size: 96,
                       color: colorScheme.error,
-                      semanticLabel: 'Warning',
                     ),
                     const SizedBox(height: 24),
                     Text(

--- a/app/lib/features/thermostats/view/alarm_fullscreen_page.dart
+++ b/app/lib/features/thermostats/view/alarm_fullscreen_page.dart
@@ -5,6 +5,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 
 import '../../../core/background/thermostat_monitor.dart';
+import '../../../core/format/error_messages.dart';
+import '../../../core/format/relative_time.dart';
+import '../../../core/format/semantics_text.dart';
 import '../models/thermostat_state.dart';
 import '../providers/thermostat_providers.dart';
 
@@ -76,7 +79,7 @@ class _AlarmFullScreenPageState extends ConsumerState<AlarmFullScreenPage> {
             child: summaryAsync.when(
               data: (summary) {
                 if (summary == null) {
-                  return const _MissingThermostat();
+                  return _MissingThermostat(thermostatId: thermostatId);
                 }
 
                 final thermostat = summary.thermostat;
@@ -91,6 +94,7 @@ class _AlarmFullScreenPageState extends ConsumerState<AlarmFullScreenPage> {
                   statusMessage: state?.statusMessage,
                   snoozedUntil: state?.snoozedUntil,
                   silenceUntilOk: state?.silenceUntilOk ?? false,
+                  lastAlarmAt: state?.lastAlarmAt,
                 );
               },
               loading: () => const Center(child: CircularProgressIndicator()),
@@ -103,7 +107,7 @@ class _AlarmFullScreenPageState extends ConsumerState<AlarmFullScreenPage> {
   }
 }
 
-class _AlarmContent extends ConsumerWidget {
+class _AlarmContent extends ConsumerStatefulWidget {
   const _AlarmContent({
     required this.thermostatId,
     required this.thermostatName,
@@ -114,6 +118,7 @@ class _AlarmContent extends ConsumerWidget {
     required this.statusMessage,
     required this.snoozedUntil,
     required this.silenceUntilOk,
+    required this.lastAlarmAt,
   });
 
   final String thermostatId;
@@ -125,65 +130,113 @@ class _AlarmContent extends ConsumerWidget {
   final String? statusMessage;
   final DateTime? snoozedUntil;
   final bool silenceUntilOk;
+  final DateTime? lastAlarmAt;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_AlarmContent> createState() => _AlarmContentState();
+}
+
+class _AlarmContentState extends ConsumerState<_AlarmContent> {
+  String get _valueText => widget.currentValue != null
+      ? '${widget.currentValue!.toStringAsFixed(1)}°C'
+      : 'Unavailable';
+
+  String? get _elapsedText {
+    final since = widget.lastAlarmAt;
+    if (since == null) {
+      return null;
+    }
+    return 'Out of range for ${formatElapsed(DateTime.now().toUtc().difference(since))}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
-    final valueText = currentValue != null
-        ? '${currentValue!.toStringAsFixed(2)}°C'
-        : 'Unavailable';
-
     final statusDetails = _buildStatusDetails(context, textTheme, colorScheme);
+    final elapsed = _elapsedText;
 
-    return Padding(
+    return SingleChildScrollView(
       padding: const EdgeInsets.all(24),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.center,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          minHeight: MediaQuery.sizeOf(context).height - 48,
+        ),
+        child: IntrinsicHeight(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              const SizedBox(height: 24),
-              Icon(
-                Icons.warning_amber_rounded,
-                size: 96,
-                color: colorScheme.error,
-              ),
-              const SizedBox(height: 24),
-              Text(
-                thermostatName,
-                style: textTheme.headlineMedium?.copyWith(
-                  color: colorScheme.onSurface,
-                  fontWeight: FontWeight.bold,
+              Semantics(
+                liveRegion: true,
+                container: true,
+                label: spokenText(
+                  'Alarm. ${widget.thermostatName}. Current $_valueText. '
+                  'Safe range ${widget.minC.toStringAsFixed(1)}°C to '
+                  '${widget.maxC.toStringAsFixed(1)}°C.'
+                  '${elapsed != null ? ' $elapsed.' : ''}',
                 ),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 16),
-              Text(
-                valueText,
-                style: textTheme.displayMedium?.copyWith(
-                  color: colorScheme.error,
-                  fontWeight: FontWeight.bold,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const SizedBox(height: 24),
+                    Icon(
+                      Icons.warning_amber_rounded,
+                      size: 96,
+                      color: colorScheme.error,
+                      semanticLabel: 'Warning',
+                    ),
+                    const SizedBox(height: 24),
+                    Text(
+                      widget.thermostatName,
+                      style: textTheme.headlineMedium?.copyWith(
+                        color: colorScheme.onSurface,
+                        fontWeight: FontWeight.bold,
+                      ),
+                      textAlign: TextAlign.center,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      _valueText,
+                      style: textTheme.displayMedium?.copyWith(
+                        color: colorScheme.error,
+                        fontWeight: FontWeight.bold,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      'Target range ${widget.minC.toStringAsFixed(1)}°C – ${widget.maxC.toStringAsFixed(1)}°C',
+                      style: textTheme.titleMedium?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                    if (elapsed != null) ...[
+                      const SizedBox(height: 8),
+                      Text(
+                        elapsed,
+                        style: textTheme.titleMedium?.copyWith(
+                          color: colorScheme.error,
+                          fontWeight: FontWeight.w600,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                    const SizedBox(height: 24),
+                    statusDetails,
+                  ],
                 ),
-              ),
-              const SizedBox(height: 8),
-              Text(
-                'Target range ${minC.toStringAsFixed(2)}°C – ${maxC.toStringAsFixed(2)}°C',
-                style: textTheme.titleMedium?.copyWith(
-                  color: colorScheme.onSurfaceVariant,
-                ),
-                textAlign: TextAlign.center,
               ),
               const SizedBox(height: 24),
-              statusDetails,
+              _AlarmActions(
+                thermostatId: widget.thermostatId,
+                silenceUntilOk: widget.silenceUntilOk,
+              ),
             ],
           ),
-          _AlarmActions(
-            thermostatId: thermostatId,
-            silenceUntilOk: silenceUntilOk,
-          ),
-        ],
+        ),
       ),
     );
   }
@@ -194,31 +247,20 @@ class _AlarmContent extends ConsumerWidget {
     ColorScheme colorScheme,
   ) {
     final buffer = <String>[];
-    if (statusMessage != null && statusMessage!.isNotEmpty) {
-      buffer.add(statusMessage!);
+    if (widget.statusMessage != null && widget.statusMessage!.isNotEmpty) {
+      buffer.add(widget.statusMessage!);
     }
-    if (snoozedUntil != null) {
+    if (widget.snoozedUntil != null) {
       final formattedTime = MaterialLocalizations.of(
         context,
-      ).formatTimeOfDay(TimeOfDay.fromDateTime(snoozedUntil!.toLocal()));
+      ).formatTimeOfDay(TimeOfDay.fromDateTime(widget.snoozedUntil!.toLocal()));
       buffer.add('Snoozed until $formattedTime');
     }
-    if (silenceUntilOk) {
-      buffer.add('Silenced until reading returns to range.');
+    if (widget.silenceUntilOk) {
+      buffer.add('Silenced until the reading returns to range.');
     }
-    if (buffer.isEmpty) {
-      switch (status) {
-        case ThermostatReadingStatus.outOfRange:
-          buffer.add('Temperature is outside the configured range.');
-          break;
-        case ThermostatReadingStatus.networkError:
-        case ThermostatReadingStatus.httpError:
-        case ThermostatReadingStatus.parseError:
-        case ThermostatReadingStatus.unknown:
-        case ThermostatReadingStatus.ok:
-        case null:
-          break;
-      }
+    if (buffer.isEmpty && widget.status == ThermostatReadingStatus.outOfRange) {
+      buffer.add('Temperature is outside the configured range.');
     }
 
     return Column(
@@ -273,50 +315,72 @@ class _AlarmActions extends ConsumerWidget {
     }
   }
 
+  Future<void> _acknowledge(BuildContext context, WidgetRef ref) async {
+    // Stop the current alert but leave monitoring armed — the next out-of-range
+    // run will alert again. No snooze/silence flag is set.
+    await cancelAlarmNotification(thermostatId);
+    if (context.mounted) {
+      Navigator.of(context).pop();
+    }
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final textTheme = Theme.of(context).textTheme;
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final colorScheme = theme.colorScheme;
+
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Wrap(
-          alignment: WrapAlignment.center,
-          spacing: 12,
-          runSpacing: 12,
-          children: [
-            FilledButton(
-              onPressed: () =>
-                  _setSnooze(context, ref, const Duration(minutes: 5)),
-              child: const Text('Snooze 5 min'),
-            ),
-            FilledButton.tonal(
-              onPressed: () =>
-                  _setSnooze(context, ref, const Duration(minutes: 10)),
-              child: const Text('Snooze 10 min'),
-            ),
-            FilledButton.tonal(
-              onPressed: () =>
-                  _setSnooze(context, ref, const Duration(minutes: 30)),
-              child: const Text('Snooze 30 min'),
-            ),
-            OutlinedButton(
-              onPressed: silenceUntilOk
-                  ? null
-                  : () => _setSilence(context, ref),
-              child: const Text('Silence until OK'),
-            ),
-          ],
+        // Primary, safest action: stop the noise, stay armed.
+        FilledButton(
+          style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(56)),
+          onPressed: () => _acknowledge(context, ref),
+          child: const Text('Acknowledge'),
         ),
-        const SizedBox(height: 24),
-        TextButton(
-          onPressed: () async {
-            await cancelAlarmNotification(thermostatId);
-            if (!context.mounted) {
-              return;
-            }
-            Navigator.of(context).pop();
-          },
-          child: Text('Dismiss', style: textTheme.titleMedium),
+        const SizedBox(height: 6),
+        Text(
+          "Stops the alarm now. You'll be alerted again if it stays out of range.",
+          style: textTheme.bodySmall?.copyWith(
+            color: colorScheme.onSurfaceVariant,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 16),
+        FilledButton.tonal(
+          style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(52)),
+          onPressed: () => _setSnooze(context, ref, const Duration(minutes: 5)),
+          child: const Text('Snooze 5 minutes'),
+        ),
+        const SizedBox(height: 12),
+        FilledButton.tonal(
+          style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(52)),
+          onPressed: () =>
+              _setSnooze(context, ref, const Duration(minutes: 10)),
+          child: const Text('Snooze 10 minutes'),
+        ),
+        const SizedBox(height: 12),
+        FilledButton.tonal(
+          style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(52)),
+          onPressed: () =>
+              _setSnooze(context, ref, const Duration(minutes: 30)),
+          child: const Text('Snooze 30 minutes'),
+        ),
+        const SizedBox(height: 12),
+        // Most-suppressing action, visually separated and clearly labelled.
+        Tooltip(
+          message: silenceUntilOk
+              ? 'Already silenced until the reading returns to range'
+              : 'Mutes alerts until the temperature is back in range',
+          child: OutlinedButton.icon(
+            style: OutlinedButton.styleFrom(
+              minimumSize: const Size.fromHeight(52),
+            ),
+            onPressed: silenceUntilOk ? null : () => _setSilence(context, ref),
+            icon: const Icon(Icons.notifications_off_outlined),
+            label: const Text('Silence until back in range'),
+          ),
         ),
       ],
     );
@@ -324,17 +388,42 @@ class _AlarmActions extends ConsumerWidget {
 }
 
 class _MissingThermostat extends StatelessWidget {
-  const _MissingThermostat();
+  const _MissingThermostat({required this.thermostatId});
+
+  final String thermostatId;
 
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
     final colorScheme = Theme.of(context).colorScheme;
     return Center(
-      child: Text(
-        'Thermostat not found.',
-        style: textTheme.titleMedium?.copyWith(color: colorScheme.onSurface),
-        textAlign: TextAlign.center,
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'Thermostat not found. It may have been removed.',
+              style: textTheme.titleMedium?.copyWith(
+                color: colorScheme.onSurface,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            FilledButton(
+              style: FilledButton.styleFrom(
+                minimumSize: const Size.fromHeight(52),
+              ),
+              onPressed: () async {
+                await cancelAlarmNotification(thermostatId);
+                if (context.mounted) {
+                  Navigator.of(context).pop();
+                }
+              },
+              child: const Text('Dismiss'),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -353,7 +442,7 @@ class _AlarmError extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.all(24),
         child: Text(
-          'Failed to load alarm details: $error',
+          humanizeError(error),
           textAlign: TextAlign.center,
           style: textTheme.titleMedium?.copyWith(color: colorScheme.onSurface),
         ),

--- a/app/lib/features/thermostats/view/thermostat_detail_page.dart
+++ b/app/lib/features/thermostats/view/thermostat_detail_page.dart
@@ -2,10 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../models/history_range.dart';
 import '../providers/thermostat_providers.dart';
+import '../widgets/history_range_selector.dart';
 import '../widgets/thermostat_card.dart';
 import '../widgets/thermostat_history_chart.dart';
+import '../../../core/format/error_messages.dart';
 import '../../../core/router/app_router.dart';
 
 class ThermostatDetailPage extends ConsumerStatefulWidget {
@@ -19,17 +20,25 @@ class ThermostatDetailPage extends ConsumerStatefulWidget {
 }
 
 class _ThermostatDetailPageState extends ConsumerState<ThermostatDetailPage> {
-  ThermostatHistoryRange _range = ThermostatHistoryRange.day;
+  void _refreshHistory() {
+    ref.invalidate(
+      thermostatHistoryRefreshProvider((
+        thermostatId: widget.thermostatId,
+        prioritizeLastHour: true,
+      )),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
     final summaryAsync = ref.watch(
       thermostatSummaryProvider(widget.thermostatId),
     );
+    final range = ref.watch(selectedHistoryRangeProvider(widget.thermostatId));
     final historyAsync = ref.watch(
       thermostatHistoryProvider((
         thermostatId: widget.thermostatId,
-        range: _range,
+        range: range,
       )),
     );
     final refreshAsync = ref.watch(
@@ -40,37 +49,35 @@ class _ThermostatDetailPageState extends ConsumerState<ThermostatDetailPage> {
     );
 
     final title = summaryAsync.asData?.value?.thermostat.name ?? 'Thermostat';
+    // A missing thermostat (deleted/removed) has data that is explicitly null.
+    final isMissing = summaryAsync.hasValue && summaryAsync.value == null;
 
     return Scaffold(
       appBar: AppBar(
         title: Text(title),
         actions: [
-          IconButton(
-            onPressed: refreshAsync.isLoading
-                ? null
-                : () {
-                    ref.invalidate(
-                      thermostatHistoryRefreshProvider((
-                        thermostatId: widget.thermostatId,
-                        prioritizeLastHour: true,
-                      )),
-                    );
-                  },
-            icon: refreshAsync.isLoading
-                ? const SizedBox(
-                    width: 20,
-                    height: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : const Icon(Icons.refresh),
-            tooltip: 'Refresh history',
-          ),
+          if (!isMissing)
+            IconButton(
+              onPressed: refreshAsync.isLoading ? null : _refreshHistory,
+              icon: refreshAsync.isLoading
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.refresh),
+              tooltip: 'Refresh history',
+            ),
         ],
       ),
       body: summaryAsync.when(
         data: (summary) {
           if (summary == null) {
-            return const _DetailNotFound();
+            return _DetailNotFound(
+              onBack: () => context.canPop()
+                  ? context.pop()
+                  : context.goNamed(ThermostatsRoute.name),
+            );
           }
           return RefreshIndicator(
             onRefresh: () async {
@@ -144,55 +151,46 @@ class _ThermostatDetailPageState extends ConsumerState<ThermostatDetailPage> {
                                       pathParameters: {
                                         'id': widget.thermostatId,
                                       },
-                                      queryParameters: {'range': _range.name},
+                                      queryParameters: {'range': range.name},
                                     );
                                   },
                                 ),
                               ],
                             ),
                             const SizedBox(height: 16),
-                            // Scrolls horizontally so the six segments don't
-                            // overflow on narrow phones or at large text scales.
-                            SingleChildScrollView(
-                              scrollDirection: Axis.horizontal,
-                              child: SegmentedButton<ThermostatHistoryRange>(
-                                showSelectedIcon: false,
-                                segments: [
-                                  for (final range
-                                      in ThermostatHistoryRange.values)
-                                    ButtonSegment(
-                                      value: range,
-                                      label: Text(range.label),
-                                      tooltip: range.description,
-                                    ),
-                                ],
-                                selected: {_range},
-                                onSelectionChanged: (selection) {
-                                  if (selection.isEmpty) {
-                                    return;
-                                  }
-                                  setState(() => _range = selection.first);
-                                },
-                              ),
+                            HistoryRangeSelector(
+                              range: range,
+                              onChanged: (value) =>
+                                  ref
+                                          .read(
+                                            selectedHistoryRangeProvider(
+                                              widget.thermostatId,
+                                            ).notifier,
+                                          )
+                                          .state =
+                                      value,
                             ),
                           ],
                         ),
                       ),
                       const SizedBox(height: 12),
-                      if (refreshAsync.isLoading)
-                        const LinearProgressIndicator(minHeight: 2),
                       Padding(
                         padding: const EdgeInsets.all(20),
                         child: historyAsync.when(
                           data: (samples) => ThermostatHistoryChart(
                             samples: samples,
-                            range: _range,
+                            range: range,
+                            minC: summary.thermostat.minC,
+                            maxC: summary.thermostat.maxC,
                           ),
                           loading: () => const SizedBox(
-                            height: 180,
+                            height: 240,
                             child: Center(child: CircularProgressIndicator()),
                           ),
-                          error: (error, _) => _HistoryError(error: error),
+                          error: (error, _) => _HistoryError(
+                            error: error,
+                            onRetry: _refreshHistory,
+                          ),
                         ),
                       ),
                     ],
@@ -229,12 +227,12 @@ class _DetailError extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             Text(
-              'Failed to load thermostat.',
+              'Failed to load thermostat',
               style: Theme.of(context).textTheme.titleMedium,
             ),
             const SizedBox(height: 8),
             Text(
-              '$error',
+              humanizeError(error),
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
                 color: Theme.of(context).colorScheme.onSurfaceVariant,
               ),
@@ -248,7 +246,9 @@ class _DetailError extends StatelessWidget {
 }
 
 class _DetailNotFound extends StatelessWidget {
-  const _DetailNotFound();
+  const _DetailNotFound({required this.onBack});
+
+  final VoidCallback onBack;
 
   @override
   Widget build(BuildContext context) {
@@ -265,7 +265,7 @@ class _DetailNotFound extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             Text(
-              'Thermostat not found.',
+              'Thermostat not found',
               style: Theme.of(context).textTheme.titleMedium,
             ),
             const SizedBox(height: 8),
@@ -276,6 +276,12 @@ class _DetailNotFound extends StatelessWidget {
               ),
               textAlign: TextAlign.center,
             ),
+            const SizedBox(height: 20),
+            FilledButton.icon(
+              onPressed: onBack,
+              icon: const Icon(Icons.arrow_back),
+              label: const Text('Back to thermostats'),
+            ),
           ],
         ),
       ),
@@ -284,9 +290,10 @@ class _DetailNotFound extends StatelessWidget {
 }
 
 class _HistoryError extends StatelessWidget {
-  const _HistoryError({required this.error});
+  const _HistoryError({required this.error, required this.onRetry});
 
   final Object error;
+  final VoidCallback onRetry;
 
   @override
   Widget build(BuildContext context) {
@@ -296,16 +303,22 @@ class _HistoryError extends StatelessWidget {
         Icon(Icons.history, color: Theme.of(context).colorScheme.error),
         const SizedBox(height: 8),
         Text(
-          'Unable to load history.',
+          'Unable to load history',
           style: Theme.of(context).textTheme.bodyMedium,
         ),
         const SizedBox(height: 4),
         Text(
-          '$error',
+          humanizeError(error),
           style: Theme.of(context).textTheme.bodySmall?.copyWith(
             color: Theme.of(context).colorScheme.onSurfaceVariant,
           ),
           textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 12),
+        OutlinedButton.icon(
+          onPressed: onRetry,
+          icon: const Icon(Icons.refresh),
+          label: const Text('Retry'),
         ),
       ],
     );

--- a/app/lib/features/thermostats/view/thermostat_history_fullscreen_page.dart
+++ b/app/lib/features/thermostats/view/thermostat_history_fullscreen_page.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/history_range.dart';
 import '../models/temperature_sample.dart';
 import '../providers/thermostat_providers.dart';
+import '../widgets/history_range_selector.dart';
 import '../widgets/thermostat_history_chart.dart';
+import '../../../core/format/error_messages.dart';
 
 class ThermostatHistoryFullscreenPage extends ConsumerStatefulWidget {
   const ThermostatHistoryFullscreenPage({
@@ -24,22 +25,23 @@ class ThermostatHistoryFullscreenPage extends ConsumerStatefulWidget {
 
 class _ThermostatHistoryFullscreenPageState
     extends ConsumerState<ThermostatHistoryFullscreenPage> {
-  late ThermostatHistoryRange _range;
-
   @override
   void initState() {
     super.initState();
-    _range = widget.initialRange;
-    SystemChrome.setPreferredOrientations(const [
-      DeviceOrientation.landscapeLeft,
-      DeviceOrientation.landscapeRight,
-    ]);
+    // Honour a deep-linked range without forcing device orientation — the
+    // chart is responsive in both portrait and landscape.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ref
+              .read(selectedHistoryRangeProvider(widget.thermostatId).notifier)
+              .state =
+          widget.initialRange;
+    });
   }
 
-  @override
-  void dispose() {
-    SystemChrome.setPreferredOrientations(DeviceOrientation.values);
-    super.dispose();
+  void _setRange(ThermostatHistoryRange range) {
+    ref.read(selectedHistoryRangeProvider(widget.thermostatId).notifier).state =
+        range;
   }
 
   Future<void> _refreshHistory() async {
@@ -62,10 +64,11 @@ class _ThermostatHistoryFullscreenPageState
     final summaryAsync = ref.watch(
       thermostatSummaryProvider(widget.thermostatId),
     );
+    final range = ref.watch(selectedHistoryRangeProvider(widget.thermostatId));
     final historyAsync = ref.watch(
       thermostatHistoryProvider((
         thermostatId: widget.thermostatId,
-        range: _range,
+        range: range,
       )),
     );
     final refreshAsync = ref.watch(
@@ -75,7 +78,8 @@ class _ThermostatHistoryFullscreenPageState
       )),
     );
 
-    final thermostatName = summaryAsync.asData?.value?.thermostat.name;
+    final thermostat = summaryAsync.asData?.value?.thermostat;
+    final thermostatName = thermostat?.name;
     final orientation = MediaQuery.of(context).orientation;
 
     return Scaffold(
@@ -98,11 +102,11 @@ class _ThermostatHistoryFullscreenPageState
                 constraints: const BoxConstraints(maxWidth: 140),
                 child: DropdownButtonHideUnderline(
                   child: DropdownButton<ThermostatHistoryRange>(
-                    value: _range,
+                    value: range,
                     isExpanded: true,
                     onChanged: (value) {
                       if (value != null) {
-                        setState(() => _range = value);
+                        _setRange(value);
                       }
                     },
                     items: [
@@ -134,8 +138,10 @@ class _ThermostatHistoryFullscreenPageState
           builder: (context, orientation) {
             final chart = _HistoryChartPane(
               historyAsync: historyAsync,
-              refreshAsync: refreshAsync,
-              range: _range,
+              range: range,
+              minC: thermostat?.minC,
+              maxC: thermostat?.maxC,
+              onRetry: _refreshHistory,
               fullBleed: orientation == Orientation.landscape,
             );
 
@@ -144,10 +150,9 @@ class _ThermostatHistoryFullscreenPageState
                 padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    // Controls moved to AppBar in landscape to maximise chart space
-                    Expanded(child: chart),
-                  ],
+                  // Range control lives in the AppBar in landscape to maximise
+                  // chart space.
+                  children: [Expanded(child: chart)],
                 ),
               );
             }
@@ -155,12 +160,15 @@ class _ThermostatHistoryFullscreenPageState
             return Padding(
               padding: const EdgeInsets.all(16),
               child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  _HistoryControls(
-                    range: _range,
-                    onRangeChanged: (range) {
-                      setState(() => _range = range);
-                    },
+                  HistoryRangeSelector(range: range, onChanged: _setRange),
+                  const SizedBox(height: 4),
+                  Text(
+                    range.description,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
                   ),
                   const SizedBox(height: 8),
                   Expanded(child: chart),
@@ -174,101 +182,39 @@ class _ThermostatHistoryFullscreenPageState
   }
 }
 
-// Legacy landscape controls removed; controls now live in the AppBar.
-
-class _HistoryControls extends StatelessWidget {
-  const _HistoryControls({required this.range, required this.onRangeChanged});
-
-  final ThermostatHistoryRange range;
-  final ValueChanged<ThermostatHistoryRange> onRangeChanged;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-
-    // Compact, single-row controls to maximise vertical space for the chart
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          children: [
-            Text(
-              'Range',
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: DropdownButtonHideUnderline(
-                child: DropdownButton<ThermostatHistoryRange>(
-                  value: range,
-                  isExpanded: true,
-                  onChanged: (value) {
-                    if (value != null) {
-                      onRangeChanged(value);
-                    }
-                  },
-                  items: [
-                    for (final option in ThermostatHistoryRange.values)
-                      DropdownMenuItem(
-                        value: option,
-                        child: Text(option.label),
-                      ),
-                  ],
-                ),
-              ),
-            ),
-          ],
-        ),
-        const SizedBox(height: 4),
-        Text(
-          range.description,
-          style: theme.textTheme.bodySmall?.copyWith(
-            color: colorScheme.onSurfaceVariant,
-          ),
-        ),
-      ],
-    );
-  }
-}
-
 class _HistoryChartPane extends StatelessWidget {
   const _HistoryChartPane({
     required this.historyAsync,
-    required this.refreshAsync,
     required this.range,
+    required this.minC,
+    required this.maxC,
+    required this.onRetry,
     this.fullBleed = false,
   });
 
   final AsyncValue<List<TemperatureSample>> historyAsync;
-  final AsyncValue<void> refreshAsync;
   final ThermostatHistoryRange range;
+  final double? minC;
+  final double? maxC;
+  final VoidCallback onRetry;
   final bool fullBleed;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final chartContent = Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        if (refreshAsync.isLoading) const LinearProgressIndicator(minHeight: 2),
-        Expanded(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-            child: historyAsync.when(
-              data: (samples) => ThermostatHistoryChart(
-                samples: samples,
-                range: range,
-                expand: true,
-              ),
-              loading: () => const Center(child: CircularProgressIndicator()),
-              error: (error, _) => _HistoryErrorView(error: error),
-            ),
-          ),
+    final chartContent = Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: historyAsync.when(
+        data: (samples) => ThermostatHistoryChart(
+          samples: samples,
+          range: range,
+          minC: minC,
+          maxC: maxC,
+          expand: true,
         ),
-      ],
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => _HistoryErrorView(error: error, onRetry: onRetry),
+      ),
     );
 
     if (fullBleed) {
@@ -289,9 +235,10 @@ class _HistoryChartPane extends StatelessWidget {
 }
 
 class _HistoryErrorView extends StatelessWidget {
-  const _HistoryErrorView({required this.error});
+  const _HistoryErrorView({required this.error, required this.onRetry});
 
   final Object error;
+  final VoidCallback onRetry;
 
   @override
   Widget build(BuildContext context) {
@@ -303,17 +250,23 @@ class _HistoryErrorView extends StatelessWidget {
           Icon(Icons.error_outline, size: 40, color: theme.colorScheme.error),
           const SizedBox(height: 12),
           Text(
-            'Failed to load history.',
+            'Failed to load history',
             style: theme.textTheme.titleMedium,
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 8),
           Text(
-            '$error',
+            humanizeError(error),
             style: theme.textTheme.bodySmall?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
             textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 12),
+          OutlinedButton.icon(
+            onPressed: onRetry,
+            icon: const Icon(Icons.refresh),
+            label: const Text('Retry'),
           ),
         ],
       ),

--- a/app/lib/features/thermostats/view/thermostats_page.dart
+++ b/app/lib/features/thermostats/view/thermostats_page.dart
@@ -164,6 +164,9 @@ class ThermostatsPage extends ConsumerWidget {
       messenger.showSnackBar(
         SnackBar(
           content: const Text('Thermostat deleted'),
+          // Longer window than the 4s default: deletion drops reading history,
+          // so give the user time to notice and undo.
+          duration: const Duration(seconds: 8),
           action: SnackBarAction(
             label: 'Undo',
             onPressed: () async {

--- a/app/lib/features/thermostats/view/thermostats_page.dart
+++ b/app/lib/features/thermostats/view/thermostats_page.dart
@@ -7,6 +7,8 @@ import '../models/thermostat_state.dart';
 import '../providers/thermostat_providers.dart';
 import '../widgets/thermostat_card.dart';
 import '../widgets/thermostat_form_dialog.dart';
+import '../../../core/background/thermostat_monitor.dart';
+import '../../../core/format/error_messages.dart';
 import '../../../core/router/app_router.dart';
 import '../../settings/providers/settings_providers.dart';
 
@@ -26,6 +28,8 @@ class ThermostatsPage extends ConsumerWidget {
             tokenOverride: config.githubToken,
           );
         },
+        onSaveWithoutTest: (draft) =>
+            ref.read(thermostatRepositoryProvider).create(draft),
       ),
     );
 
@@ -35,7 +39,7 @@ class ThermostatsPage extends ConsumerWidget {
 
     ScaffoldMessenger.of(
       context,
-    ).showSnackBar(const SnackBar(content: Text('Thermostat added.')));
+    ).showSnackBar(const SnackBar(content: Text('Thermostat added')));
   }
 
   Future<void> _editThermostat(
@@ -58,6 +62,8 @@ class ThermostatsPage extends ConsumerWidget {
             tokenOverride: config.githubToken,
           );
         },
+        onSaveWithoutTest: (draft) =>
+            ref.read(thermostatRepositoryProvider).update(thermostat, draft),
       ),
     );
 
@@ -67,7 +73,7 @@ class ThermostatsPage extends ConsumerWidget {
 
     ScaffoldMessenger.of(
       context,
-    ).showSnackBar(const SnackBar(content: Text('Thermostat updated.')));
+    ).showSnackBar(const SnackBar(content: Text('Thermostat updated')));
   }
 
   Future<void> _refreshThermostat(
@@ -88,19 +94,22 @@ class ThermostatsPage extends ConsumerWidget {
         ThermostatReadingStatus.ok => false,
         _ => true,
       };
+      final scheme = Theme.of(context).colorScheme;
       messenger.showSnackBar(
         SnackBar(
           content: Text(message),
-          backgroundColor: isError ? Theme.of(context).colorScheme.error : null,
+          backgroundColor: isError ? scheme.error : null,
         ),
       );
     } catch (error) {
       if (!context.mounted) {
         return;
       }
+      final scheme = Theme.of(context).colorScheme;
       messenger.showSnackBar(
         SnackBar(
-          content: Text('Failed to refresh ${summary.thermostat.name}: $error'),
+          content: Text('${summary.thermostat.name}: ${humanizeError(error)}'),
+          backgroundColor: scheme.error,
         ),
       );
     }
@@ -115,6 +124,7 @@ class ThermostatsPage extends ConsumerWidget {
     final confirm = await showDialog<bool>(
       context: context,
       builder: (context) {
+        final scheme = Theme.of(context).colorScheme;
         return AlertDialog(
           title: const Text('Delete thermostat'),
           content: Text('Delete "${thermostat.name}"?'),
@@ -124,6 +134,10 @@ class ThermostatsPage extends ConsumerWidget {
               child: const Text('Cancel'),
             ),
             FilledButton(
+              style: FilledButton.styleFrom(
+                backgroundColor: scheme.error,
+                foregroundColor: scheme.onError,
+              ),
               onPressed: () => Navigator.of(context).pop(true),
               child: const Text('Delete'),
             ),
@@ -141,97 +155,143 @@ class ThermostatsPage extends ConsumerWidget {
     }
 
     final repository = ref.read(thermostatRepositoryProvider);
+    final messenger = ScaffoldMessenger.of(context);
     try {
       await repository.delete(thermostat.id);
       if (!context.mounted) {
         return;
       }
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('Thermostat deleted.')));
+      messenger.showSnackBar(
+        SnackBar(
+          content: const Text('Thermostat deleted'),
+          action: SnackBarAction(
+            label: 'Undo',
+            onPressed: () async {
+              // Restores the configuration (reading history is not recovered).
+              try {
+                await repository.restore(thermostat);
+              } catch (_) {
+                // If the restore fails the row simply stays deleted.
+              }
+            },
+          ),
+        ),
+      );
     } catch (error) {
       if (!context.mounted) {
         return;
       }
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to delete thermostat: $error')),
-      );
+      messenger.showSnackBar(SnackBar(content: Text(humanizeError(error))));
     }
+  }
+
+  Future<void> _resumeMonitoring(BuildContext context, WidgetRef ref) async {
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await ref.read(alertConfigRepositoryProvider).clearPause();
+      await initializeBackgroundMonitoring();
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Monitoring resumed')),
+      );
+    } catch (error) {
+      messenger.showSnackBar(SnackBar(content: Text(humanizeError(error))));
+    }
+  }
+
+  Future<void> _refreshAll(WidgetRef ref, List<ThermostatSummary> items) async {
+    final service = ref.read(thermostatServiceProvider);
+    for (final summary in items) {
+      try {
+        await service.refresh(summary.thermostat);
+      } catch (_) {
+        // Per-thermostat failures are reflected in each card's status; the
+        // pull-to-refresh gesture shouldn't fail wholesale on one bad sensor.
+      }
+    }
+  }
+
+  Widget _buildGrid(
+    BuildContext context,
+    WidgetRef ref,
+    List<ThermostatSummary> thermostats,
+  ) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        final crossAxisCount = switch (width) {
+          >= 1200 => 3,
+          >= 760 => 2,
+          _ => 1,
+        };
+        final bottomPadding = MediaQuery.of(context).padding.bottom;
+        final padding = EdgeInsets.fromLTRB(16, 16, 16, 24 + bottomPadding);
+
+        ThermostatCard buildCard(ThermostatSummary summary) => ThermostatCard(
+          summary: summary,
+          onEdit: () => _editThermostat(context, ref, summary),
+          onDelete: () => _deleteThermostat(context, ref, summary),
+          onRefresh: () => _refreshThermostat(context, ref, summary),
+          onTap: () => context.pushNamed(
+            ThermostatDetailRoute.name,
+            pathParameters: {'id': summary.thermostat.id},
+          ),
+        );
+
+        if (crossAxisCount == 1) {
+          return ListView.separated(
+            padding: padding,
+            physics: const AlwaysScrollableScrollPhysics(),
+            itemCount: thermostats.length,
+            separatorBuilder: (context, _) => const SizedBox(height: 18),
+            itemBuilder: (context, index) => buildCard(thermostats[index]),
+          );
+        }
+
+        const spacing = 18.0;
+        // Height is driven by content (not a fixed aspect ratio) so cards don't
+        // overflow at large text scales.
+        return GridView.builder(
+          padding: padding,
+          primary: false,
+          physics: const AlwaysScrollableScrollPhysics(),
+          gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
+            maxCrossAxisExtent: width / crossAxisCount,
+            mainAxisSpacing: spacing,
+            crossAxisSpacing: spacing,
+            mainAxisExtent: 280,
+          ),
+          itemCount: thermostats.length,
+          itemBuilder: (context, index) => buildCard(thermostats[index]),
+        );
+      },
+    );
   }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final asyncThermostats = ref.watch(thermostatsProvider);
     final offlineStatus = ref.watch(offlineStatusProvider);
+    final config = ref.watch(alertConfigProvider).asData?.value;
+    final now = DateTime.now().toUtc();
+    final pausedUntil = (config != null && config.isPaused(now))
+        ? config.pauseAllUntil
+        : null;
 
     final content = asyncThermostats.when(
       data: (thermostats) {
         if (thermostats.isEmpty) {
-          return const _EmptyState();
+          return _EmptyState(onAdd: () => _createThermostat(context, ref));
         }
-
-        return LayoutBuilder(
-          builder: (context, constraints) {
-            final width = constraints.maxWidth;
-            final crossAxisCount = switch (width) {
-              >= 1200 => 3,
-              >= 760 => 2,
-              _ => 1,
-            };
-            final bottomPadding = MediaQuery.of(context).padding.bottom;
-            final padding = EdgeInsets.fromLTRB(16, 16, 16, 24 + bottomPadding);
-
-            if (crossAxisCount == 1) {
-              return ListView.separated(
-                padding: padding,
-                itemCount: thermostats.length,
-                separatorBuilder: (context, _) => const SizedBox(height: 18),
-                itemBuilder: (context, index) {
-                  final summary = thermostats[index];
-                  return ThermostatCard(
-                    summary: summary,
-                    onEdit: () => _editThermostat(context, ref, summary),
-                    onDelete: () => _deleteThermostat(context, ref, summary),
-                    onRefresh: () => _refreshThermostat(context, ref, summary),
-                    onTap: () => context.pushNamed(
-                      ThermostatDetailRoute.name,
-                      pathParameters: {'id': summary.thermostat.id},
-                    ),
-                  );
-                },
-              );
-            }
-
-            const spacing = 18.0;
-            return GridView.builder(
-              padding: padding,
-              primary: false,
-              gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                crossAxisCount: crossAxisCount,
-                mainAxisSpacing: spacing,
-                crossAxisSpacing: spacing,
-                childAspectRatio: 0.94,
-              ),
-              itemCount: thermostats.length,
-              itemBuilder: (context, index) {
-                final summary = thermostats[index];
-                return ThermostatCard(
-                  summary: summary,
-                  onEdit: () => _editThermostat(context, ref, summary),
-                  onDelete: () => _deleteThermostat(context, ref, summary),
-                  onRefresh: () => _refreshThermostat(context, ref, summary),
-                  onTap: () => context.pushNamed(
-                    ThermostatDetailRoute.name,
-                    pathParameters: {'id': summary.thermostat.id},
-                  ),
-                );
-              },
-            );
-          },
+        return RefreshIndicator(
+          onRefresh: () => _refreshAll(ref, thermostats),
+          child: _buildGrid(context, ref, thermostats),
         );
       },
       loading: () => const Center(child: CircularProgressIndicator()),
-      error: (error, stackTrace) => _ErrorState(error: error),
+      error: (error, stackTrace) => _ErrorState(
+        error: error,
+        onRetry: () => ref.invalidate(thermostatsProvider),
+      ),
     );
 
     final showOfflineBanner =
@@ -243,6 +303,20 @@ class ThermostatsPage extends ConsumerWidget {
       body: SafeArea(
         child: Column(
           children: [
+            AnimatedSwitcher(
+              duration: const Duration(milliseconds: 250),
+              switchInCurve: Curves.easeOut,
+              switchOutCurve: Curves.easeIn,
+              child: pausedUntil != null
+                  ? Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+                      child: _PauseBanner(
+                        resumesAt: pausedUntil,
+                        onResume: () => _resumeMonitoring(context, ref),
+                      ),
+                    )
+                  : const SizedBox.shrink(),
+            ),
             AnimatedSwitcher(
               duration: const Duration(milliseconds: 250),
               switchInCurve: Curves.easeOut,
@@ -267,6 +341,75 @@ class ThermostatsPage extends ConsumerWidget {
   }
 }
 
+class _PauseBanner extends StatelessWidget {
+  const _PauseBanner({required this.resumesAt, required this.onResume});
+
+  final DateTime resumesAt;
+  final VoidCallback onResume;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final resumeTime = MaterialLocalizations.of(
+      context,
+    ).formatTimeOfDay(TimeOfDay.fromDateTime(resumesAt.toLocal()));
+    final message = 'Alarms are paused until $resumeTime.';
+
+    return Semantics(
+      container: true,
+      liveRegion: true,
+      label: 'Monitoring paused',
+      value: message,
+      child: Card(
+        margin: EdgeInsets.zero,
+        color: colorScheme.errorContainer,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(18, 14, 12, 14),
+          child: Row(
+            children: [
+              Icon(
+                Icons.pause_circle_outline,
+                color: colorScheme.onErrorContainer,
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Monitoring paused',
+                      style: textTheme.titleSmall?.copyWith(
+                        color: colorScheme.onErrorContainer,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      message,
+                      style: textTheme.bodyMedium?.copyWith(
+                        color: colorScheme.onErrorContainer,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              TextButton(
+                onPressed: onResume,
+                style: TextButton.styleFrom(
+                  foregroundColor: colorScheme.onErrorContainer,
+                ),
+                child: const Text('Resume'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _OfflineBanner extends StatelessWidget {
   const _OfflineBanner({required this.status});
 
@@ -277,26 +420,33 @@ class _OfflineBanner extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
 
-    final (title, message, icon) = switch (status) {
+    final (title, message, icon, avatarColor, onAvatarColor) = switch (status) {
       OfflineStatus.offline => (
         'Offline mode',
         'FarmCtl is showing the last known readings until the connection returns.',
         Icons.cloud_off,
+        colorScheme.errorContainer,
+        colorScheme.onErrorContainer,
       ),
       OfflineStatus.degraded => (
         'Connectivity issues',
         'Some thermostats are unreachable and recent values may be stale.',
         Icons.cloud_queue,
+        colorScheme.tertiaryContainer,
+        colorScheme.onTertiaryContainer,
       ),
       _ => (
         'Connectivity notice',
         'Network status is unavailable.',
         Icons.cloud_queue,
+        colorScheme.tertiaryContainer,
+        colorScheme.onTertiaryContainer,
       ),
     };
 
     return Semantics(
       container: true,
+      liveRegion: true,
       label: title,
       value: message,
       child: Card(
@@ -308,8 +458,8 @@ class _OfflineBanner extends StatelessWidget {
             children: [
               CircleAvatar(
                 radius: 20,
-                backgroundColor: colorScheme.primaryContainer,
-                foregroundColor: colorScheme.onPrimaryContainer,
+                backgroundColor: avatarColor,
+                foregroundColor: onAvatarColor,
                 child: Icon(icon),
               ),
               const SizedBox(width: 16),
@@ -342,7 +492,9 @@ class _OfflineBanner extends StatelessWidget {
 }
 
 class _EmptyState extends StatelessWidget {
-  const _EmptyState();
+  const _EmptyState({required this.onAdd});
+
+  final VoidCallback onAdd;
 
   @override
   Widget build(BuildContext context) {
@@ -366,6 +518,12 @@ class _EmptyState extends StatelessWidget {
               textAlign: TextAlign.center,
               style: textTheme.bodyMedium,
             ),
+            const SizedBox(height: 20),
+            FilledButton.icon(
+              onPressed: onAdd,
+              icon: const Icon(Icons.add),
+              label: const Text('Add thermostat'),
+            ),
           ],
         ),
       ),
@@ -374,9 +532,10 @@ class _EmptyState extends StatelessWidget {
 }
 
 class _ErrorState extends StatelessWidget {
-  const _ErrorState({required this.error});
+  const _ErrorState({required this.error, required this.onRetry});
 
   final Object error;
+  final VoidCallback onRetry;
 
   @override
   Widget build(BuildContext context) {
@@ -390,14 +549,20 @@ class _ErrorState extends StatelessWidget {
             Icon(Icons.error_outline, size: 48, color: theme.colorScheme.error),
             const SizedBox(height: 12),
             Text(
-              'Failed to load thermostats.',
+              'Failed to load thermostats',
               style: theme.textTheme.titleMedium,
             ),
             const SizedBox(height: 8),
             Text(
-              '$error',
+              humanizeError(error),
               textAlign: TextAlign.center,
               style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 20),
+            FilledButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: const Text('Retry'),
             ),
           ],
         ),

--- a/app/lib/features/thermostats/widgets/history_range_selector.dart
+++ b/app/lib/features/thermostats/widgets/history_range_selector.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+import '../models/history_range.dart';
+
+/// A single, consistent control for picking the history time range, used by
+/// both the detail page and the full-screen chart. Scrolls horizontally so the
+/// six segments never overflow on narrow phones or at large text scales.
+class HistoryRangeSelector extends StatelessWidget {
+  const HistoryRangeSelector({
+    required this.range,
+    required this.onChanged,
+    super.key,
+  });
+
+  final ThermostatHistoryRange range;
+  final ValueChanged<ThermostatHistoryRange> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: SegmentedButton<ThermostatHistoryRange>(
+        showSelectedIcon: false,
+        segments: [
+          for (final option in ThermostatHistoryRange.values)
+            ButtonSegment(
+              value: option,
+              label: Text(option.label),
+              tooltip: option.description,
+            ),
+        ],
+        selected: {range},
+        onSelectionChanged: (selection) {
+          if (selection.isEmpty) {
+            return;
+          }
+          onChanged(selection.first);
+        },
+      ),
+    );
+  }
+}

--- a/app/lib/features/thermostats/widgets/thermostat_card.dart
+++ b/app/lib/features/thermostats/widgets/thermostat_card.dart
@@ -230,31 +230,37 @@ class ThermostatCard extends StatelessWidget {
                 ),
               ),
               const SizedBox(height: 16),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20),
-                child: Wrap(
-                  spacing: 12,
-                  runSpacing: 12,
-                  children: [
-                    _MetaChip(
-                      icon: Icons.straighten,
-                      label:
-                          '${thermostat.minC.toStringAsFixed(1)}°C – ${thermostat.maxC.toStringAsFixed(1)}°C',
-                      supportingLabel: 'Target range',
-                    ),
-                    _MetaChip(
-                      icon: Icons.tag,
-                      label: thermostat.id,
-                      supportingLabel: 'Identifier',
-                    ),
-                    if (state?.statusMessage != null &&
-                        state!.statusMessage!.isNotEmpty)
+              // The chips (range, raw id, last message) and the status footer
+              // repeat what the card's Semantics `value` already announces, so
+              // exclude them to avoid a double read (and the raw id being spelled
+              // out letter by letter).
+              ExcludeSemantics(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  child: Wrap(
+                    spacing: 12,
+                    runSpacing: 12,
+                    children: [
                       _MetaChip(
-                        icon: Icons.info_outline,
-                        label: state.statusMessage!,
-                        supportingLabel: 'Last message',
+                        icon: Icons.straighten,
+                        label:
+                            '${thermostat.minC.toStringAsFixed(1)}°C – ${thermostat.maxC.toStringAsFixed(1)}°C',
+                        supportingLabel: 'Target range',
                       ),
-                  ],
+                      _MetaChip(
+                        icon: Icons.tag,
+                        label: thermostat.id,
+                        supportingLabel: 'Identifier',
+                      ),
+                      if (state?.statusMessage != null &&
+                          state!.statusMessage!.isNotEmpty)
+                        _MetaChip(
+                          icon: Icons.info_outline,
+                          label: state.statusMessage!,
+                          supportingLabel: 'Last message',
+                        ),
+                    ],
+                  ),
                 ),
               ),
               const SizedBox(height: 16),

--- a/app/lib/features/thermostats/widgets/thermostat_card.dart
+++ b/app/lib/features/thermostats/widgets/thermostat_card.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 
+import '../../../core/format/relative_time.dart';
+import '../../../core/format/semantics_text.dart';
 import '../models/thermostat_state.dart';
+import '../models/thermostat_status_presentation.dart';
 
 class ThermostatCard extends StatelessWidget {
   const ThermostatCard({
@@ -35,29 +38,37 @@ class ThermostatCard extends StatelessWidget {
         ? 'Current temperature'
         : 'Awaiting first reading';
 
-    final statusPresentation = _describeStatus(state);
-    final isAlert = statusPresentation.isError;
-    final highlightColor = isAlert
+    final statusPresentation = ThermostatStatusPresentation.fromState(state);
+    // Only an out-of-range *temperature* turns the hero panel red. Connectivity
+    // problems leave it neutral — the shown value is the last known-good one.
+    final isDanger = statusPresentation.isDanger;
+    final highlightColor = isDanger
         ? colorScheme.errorContainer
         : colorScheme.primaryContainer;
-    final highlightOnColor = isAlert
+    final highlightOnColor = isDanger
         ? colorScheme.onErrorContainer
         : colorScheme.onPrimaryContainer;
 
+    final now = DateTime.now().toUtc();
+    final lastFetchedAt = state?.lastFetchedAt;
+    final isStale =
+        lastFetchedAt != null &&
+        now.difference(lastFetchedAt) > const Duration(minutes: 30);
+
+    // Spoken status uses the short label word (not the detail line) so the
+    // temperature isn't read twice at two precisions.
     final semanticsValue = [
-      if (hasTemperature)
-        'Current ${_normalizeForSemantics(temperatureLabel)}.',
-      _normalizeForSemantics(statusPresentation.text),
+      if (hasTemperature) spokenText('Current $temperatureLabel.'),
+      'Status: ${statusPresentation.label}.',
       'Target range ${thermostat.minC.toStringAsFixed(1)} to '
           '${thermostat.maxC.toStringAsFixed(1)} degrees Celsius.',
     ].join(' ');
 
     return Semantics(
       container: true,
-      button: onTap != null,
+      explicitChildNodes: true,
       label: 'Thermostat ${thermostat.name}',
       value: semanticsValue,
-      hint: onTap != null ? 'Tap to open thermostat details.' : null,
       child: Card(
         child: InkWell(
           onTap: onTap,
@@ -176,12 +187,12 @@ class ThermostatCard extends StatelessWidget {
                             ],
                           ),
                         ),
-                        if (state?.lastFetchedAt != null)
+                        if (lastFetchedAt != null)
                           Column(
                             crossAxisAlignment: CrossAxisAlignment.end,
                             children: [
                               Text(
-                                'Last update',
+                                isStale ? 'Last update (stale)' : 'Last update',
                                 style: textTheme.labelMedium?.copyWith(
                                   color: highlightOnColor.withValues(
                                     alpha: 0.72,
@@ -189,16 +200,27 @@ class ThermostatCard extends StatelessWidget {
                                 ),
                               ),
                               const SizedBox(height: 4),
-                              Text(
-                                _formatRelativeDuration(
-                                  DateTime.now().toUtc().difference(
-                                    state!.lastFetchedAt!,
+                              Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  if (isStale) ...[
+                                    Icon(
+                                      Icons.schedule,
+                                      size: 14,
+                                      color: highlightOnColor,
+                                    ),
+                                    const SizedBox(width: 4),
+                                  ],
+                                  Text(
+                                    formatRelativeDuration(
+                                      now.difference(lastFetchedAt),
+                                    ),
+                                    style: textTheme.bodyMedium?.copyWith(
+                                      color: highlightOnColor,
+                                      fontWeight: FontWeight.w600,
+                                    ),
                                   ),
-                                ),
-                                style: textTheme.bodyMedium?.copyWith(
-                                  color: highlightOnColor,
-                                  fontWeight: FontWeight.w600,
-                                ),
+                                ],
                               ),
                             ],
                           ),
@@ -243,22 +265,29 @@ class ThermostatCard extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Icon(
-                      statusPresentation.isError
-                          ? Icons.warning_rounded
-                          : Icons.check_circle,
+                      statusPresentation.icon,
                       size: 20,
-                      color: statusPresentation.isError
-                          ? colorScheme.error
-                          : colorScheme.primary,
+                      color: statusPresentation.color(colorScheme),
                     ),
                     const SizedBox(width: 12),
                     Expanded(
-                      child: Text(
-                        statusPresentation.text,
-                        style: textTheme.bodyMedium?.copyWith(
-                          color: statusPresentation.isError
-                              ? colorScheme.error
-                              : colorScheme.onSurfaceVariant,
+                      child: Text.rich(
+                        TextSpan(
+                          children: [
+                            TextSpan(
+                              text: statusPresentation.label,
+                              style: textTheme.bodyMedium?.copyWith(
+                                color: statusPresentation.color(colorScheme),
+                                fontWeight: FontWeight.w700,
+                              ),
+                            ),
+                            TextSpan(
+                              text: '  ${statusPresentation.detail}',
+                              style: textTheme.bodyMedium?.copyWith(
+                                color: colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                          ],
                         ),
                       ),
                     ),
@@ -331,106 +360,4 @@ class _MetaChip extends StatelessWidget {
       ),
     );
   }
-}
-
-class _StatusPresentation {
-  const _StatusPresentation({required this.text, required this.isError});
-
-  final String text;
-  final bool isError;
-}
-
-_StatusPresentation _describeStatus(ThermostatState? state) {
-  if (state == null || state.lastFetchedAt == null) {
-    return const _StatusPresentation(
-      text: 'No successful readings yet.',
-      isError: false,
-    );
-  }
-
-  final fetchedAt = state.lastFetchedAt!;
-  final value = state.lastValueC;
-  final status = state.status;
-  final message = state.statusMessage;
-  final now = DateTime.now().toUtc();
-  final difference = now.difference(fetchedAt);
-  final relative = _formatRelativeDuration(difference);
-
-  switch (status) {
-    case ThermostatReadingStatus.ok:
-      final base = value != null
-          ? '${value.toStringAsFixed(2)}°C • Updated $relative'
-          : 'Updated $relative';
-      final text = message != null && message.isNotEmpty
-          ? '$message • Updated $relative'
-          : base;
-      return _StatusPresentation(text: text, isError: false);
-    case ThermostatReadingStatus.networkError:
-      final base = (message != null && message.isNotEmpty)
-          ? message
-          : 'Last attempt failed: network error';
-      return _StatusPresentation(
-        text: '$base • Checked $relative',
-        isError: true,
-      );
-    case ThermostatReadingStatus.outOfRange:
-      final base = (message != null && message.isNotEmpty)
-          ? message
-          : 'Temperature outside configured range';
-      final text = value != null
-          ? '$base (${value.toStringAsFixed(2)}°C) • Updated $relative'
-          : '$base • Updated $relative';
-      return _StatusPresentation(text: text, isError: true);
-    case ThermostatReadingStatus.httpError:
-      final base = (message != null && message.isNotEmpty)
-          ? message
-          : 'Last attempt failed: server error';
-      return _StatusPresentation(
-        text: '$base • Checked $relative',
-        isError: true,
-      );
-    case ThermostatReadingStatus.parseError:
-      final base = (message != null && message.isNotEmpty)
-          ? message
-          : 'Last attempt failed: invalid payload';
-      return _StatusPresentation(
-        text: '$base • Checked $relative',
-        isError: true,
-      );
-    case ThermostatReadingStatus.unknown:
-      final text = (message != null && message.isNotEmpty)
-          ? '$message • Checked $relative'
-          : 'Last seen $relative';
-      return _StatusPresentation(text: text, isError: true);
-  }
-}
-
-String _formatRelativeDuration(Duration difference) {
-  final seconds = difference.inSeconds.abs();
-  if (seconds < 60) {
-    return 'just now';
-  }
-  final minutes = difference.inMinutes;
-  if (minutes.abs() < 60) {
-    final value = minutes.abs();
-    final unit = value == 1 ? 'min' : 'mins';
-    return '$value $unit ago';
-  }
-  final hours = difference.inHours;
-  if (hours.abs() < 24) {
-    final value = hours.abs();
-    final unit = value == 1 ? 'hour' : 'hours';
-    return '$value $unit ago';
-  }
-  final days = difference.inDays;
-  final unit = days.abs() == 1 ? 'day' : 'days';
-  return '${days.abs()} $unit ago';
-}
-
-String _normalizeForSemantics(String input) {
-  return input
-      .replaceAll('°C', ' degrees Celsius')
-      .replaceAll('•', '.')
-      .replaceAll('  ', ' ')
-      .trim();
 }

--- a/app/lib/features/thermostats/widgets/thermostat_form_dialog.dart
+++ b/app/lib/features/thermostats/widgets/thermostat_form_dialog.dart
@@ -4,13 +4,32 @@ import '../data/thermostat_client.dart';
 import '../models/thermostat.dart';
 
 class ThermostatFormDialog extends StatefulWidget {
-  const ThermostatFormDialog({required this.onSubmit, this.initial, super.key});
+  const ThermostatFormDialog({
+    required this.onSubmit,
+    this.onSaveWithoutTest,
+    this.initial,
+    super.key,
+  });
 
+  /// Tests the sensor connection and then saves.
   final Future<Thermostat> Function(ThermostatDraft draft) onSubmit;
+
+  /// Saves the configuration without contacting the sensor. Offered as a
+  /// fallback when the connection test fails (e.g. patchy signal) so setup
+  /// isn't blocked by a transient network problem.
+  final Future<Thermostat> Function(ThermostatDraft draft)? onSaveWithoutTest;
+
   final Thermostat? initial;
 
   @override
   State<ThermostatFormDialog> createState() => _ThermostatFormDialogState();
+}
+
+String _formatBound(double value) {
+  if (value == value.roundToDouble()) {
+    return value.toStringAsFixed(0);
+  }
+  return value.toString(); // keeps minimal decimals, e.g. 4.5 not 4.50
 }
 
 class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
@@ -23,6 +42,7 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
   Map<ThermostatValidationField, String> _fieldErrors = {};
   String? _submitError;
   bool _isSubmitting = false;
+  ThermostatDraft? _pendingDraft;
 
   @override
   void initState() {
@@ -31,10 +51,10 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
     _nameController = TextEditingController(text: initial?.name ?? '');
     _urlController = TextEditingController(text: initial?.rawUrl ?? '');
     _minController = TextEditingController(
-      text: initial != null ? initial.minC.toStringAsFixed(2) : '',
+      text: initial != null ? _formatBound(initial.minC) : '',
     );
     _maxController = TextEditingController(
-      text: initial != null ? initial.maxC.toStringAsFixed(2) : '',
+      text: initial != null ? _formatBound(initial.maxC) : '',
     );
   }
 
@@ -104,6 +124,7 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
 
     setState(() {
       _isSubmitting = true;
+      _pendingDraft = draft;
     });
 
     try {
@@ -142,7 +163,34 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
         return;
       }
       setState(() {
-        _submitError = 'Failed to save thermostat: $error';
+        _submitError = 'Could not save. Please try again.';
+        _isSubmitting = false;
+      });
+    }
+  }
+
+  Future<void> _saveWithoutTest() async {
+    final draft = _pendingDraft;
+    final handler = widget.onSaveWithoutTest;
+    if (draft == null || handler == null) {
+      return;
+    }
+    setState(() {
+      _isSubmitting = true;
+      _submitError = null;
+    });
+    try {
+      final saved = await handler(draft);
+      if (!mounted) {
+        return;
+      }
+      Navigator.of(context).pop(saved);
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _submitError = 'Could not save. Please try again.';
         _isSubmitting = false;
       });
     }
@@ -151,6 +199,10 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
   @override
   Widget build(BuildContext context) {
     final isEditing = widget.initial != null;
+    final canSaveWithoutTest =
+        _submitError != null &&
+        _pendingDraft != null &&
+        widget.onSaveWithoutTest != null;
     return AlertDialog(
       title: Text(isEditing ? 'Edit thermostat' : 'Add thermostat'),
       content: SingleChildScrollView(
@@ -161,6 +213,7 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
             children: [
               TextFormField(
                 controller: _nameController,
+                maxLength: 40,
                 decoration: InputDecoration(
                   labelText: 'Name',
                   errorText: _fieldErrors[ThermostatValidationField.name],
@@ -194,12 +247,14 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
               ),
               const SizedBox(height: 12),
               Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Expanded(
                     child: TextFormField(
                       controller: _minController,
                       decoration: InputDecoration(
                         labelText: 'Min °C',
+                        helperText: 'e.g. 2',
                         errorText: _fieldErrors[ThermostatValidationField.minC],
                       ),
                       keyboardType: const TextInputType.numberWithOptions(
@@ -207,6 +262,7 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
                         decimal: true,
                       ),
                       enabled: !_isSubmitting,
+                      validator: _numberValidator,
                     ),
                   ),
                   const SizedBox(width: 16),
@@ -215,25 +271,31 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
                       controller: _maxController,
                       decoration: InputDecoration(
                         labelText: 'Max °C',
-                        errorText: _fieldErrors[ThermostatValidationField.maxC],
+                        helperText: 'e.g. 30',
+                        // The cross-field "min must be < max" error is anchored
+                        // to this field rather than floating below the row.
+                        errorText:
+                            _fieldErrors[ThermostatValidationField.maxC] ??
+                            _rangeError,
                       ),
                       keyboardType: const TextInputType.numberWithOptions(
                         signed: true,
                         decimal: true,
                       ),
                       enabled: !_isSubmitting,
+                      validator: _numberValidator,
                     ),
                   ),
                 ],
               ),
-              if (_rangeError != null) ...[
-                const SizedBox(height: 8),
+              if (_isSubmitting) ...[
+                const SizedBox(height: 12),
                 Align(
                   alignment: Alignment.centerLeft,
                   child: Text(
-                    _rangeError!,
+                    'Testing connection…',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: Theme.of(context).colorScheme.error,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
                     ),
                   ),
                 ),
@@ -259,6 +321,11 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
           onPressed: _isSubmitting ? null : () => Navigator.of(context).pop(),
           child: const Text('Cancel'),
         ),
+        if (canSaveWithoutTest)
+          TextButton(
+            onPressed: _isSubmitting ? null : _saveWithoutTest,
+            child: const Text('Save without testing'),
+          ),
         FilledButton(
           onPressed: _isSubmitting ? null : _submit,
           child: _isSubmitting
@@ -271,5 +338,16 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
         ),
       ],
     );
+  }
+
+  String? _numberValidator(String? value) {
+    final trimmed = value?.trim() ?? '';
+    if (trimmed.isEmpty) {
+      return 'Enter a number.';
+    }
+    if (double.tryParse(trimmed) == null) {
+      return 'Enter a number.';
+    }
+    return null;
   }
 }

--- a/app/lib/features/thermostats/widgets/thermostat_form_dialog.dart
+++ b/app/lib/features/thermostats/widgets/thermostat_form_dialog.dart
@@ -42,7 +42,6 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
   Map<ThermostatValidationField, String> _fieldErrors = {};
   String? _submitError;
   bool _isSubmitting = false;
-  ThermostatDraft? _pendingDraft;
 
   @override
   void initState() {
@@ -67,21 +66,21 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
     super.dispose();
   }
 
-  Future<void> _submit() async {
-    FocusScope.of(context).unfocus();
+  /// Validates the current field values and returns a draft, or null after
+  /// setting the relevant inline errors. Always reads the live controllers so a
+  /// later "save without testing" can't persist a stale snapshot.
+  ThermostatDraft? _validatedDraft() {
     setState(() {
       _fieldErrors = {};
       _rangeError = null;
-      _submitError = null;
     });
 
     if (!_formKey.currentState!.validate()) {
-      return;
+      return null;
     }
 
     final minValue = double.tryParse(_minController.text.trim());
     final maxValue = double.tryParse(_maxController.text.trim());
-
     if (minValue == null || maxValue == null) {
       setState(() {
         if (minValue == null) {
@@ -97,7 +96,7 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
           };
         }
       });
-      return;
+      return null;
     }
 
     final draft = ThermostatDraft(
@@ -119,12 +118,24 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
         }
         _fieldErrors = map;
       });
+      return null;
+    }
+    return draft;
+  }
+
+  Future<void> _submit() async {
+    FocusScope.of(context).unfocus();
+    setState(() {
+      _submitError = null;
+    });
+
+    final draft = _validatedDraft();
+    if (draft == null) {
       return;
     }
 
     setState(() {
       _isSubmitting = true;
-      _pendingDraft = draft;
     });
 
     try {
@@ -170,9 +181,15 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
   }
 
   Future<void> _saveWithoutTest() async {
-    final draft = _pendingDraft;
     final handler = widget.onSaveWithoutTest;
-    if (draft == null || handler == null) {
+    if (handler == null) {
+      return;
+    }
+    FocusScope.of(context).unfocus();
+    // Re-read and re-validate so an edit made after the failed test is saved,
+    // not the snapshot captured when the test ran.
+    final draft = _validatedDraft();
+    if (draft == null) {
       return;
     }
     setState(() {
@@ -200,9 +217,7 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
   Widget build(BuildContext context) {
     final isEditing = widget.initial != null;
     final canSaveWithoutTest =
-        _submitError != null &&
-        _pendingDraft != null &&
-        widget.onSaveWithoutTest != null;
+        _submitError != null && widget.onSaveWithoutTest != null;
     return AlertDialog(
       title: Text(isEditing ? 'Edit thermostat' : 'Add thermostat'),
       content: SingleChildScrollView(
@@ -250,40 +265,49 @@ class _ThermostatFormDialogState extends State<ThermostatFormDialog> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Expanded(
-                    child: TextFormField(
-                      controller: _minController,
-                      decoration: InputDecoration(
-                        labelText: 'Min °C',
-                        helperText: 'e.g. 2',
-                        errorText: _fieldErrors[ThermostatValidationField.minC],
+                    child: Semantics(
+                      // The visible label "Min °C" is read as "Min degree C";
+                      // give screen readers the full spoken form.
+                      label: 'Minimum temperature in degrees Celsius',
+                      child: TextFormField(
+                        controller: _minController,
+                        decoration: InputDecoration(
+                          labelText: 'Min °C',
+                          helperText: 'e.g. 2',
+                          errorText:
+                              _fieldErrors[ThermostatValidationField.minC],
+                        ),
+                        keyboardType: const TextInputType.numberWithOptions(
+                          signed: true,
+                          decimal: true,
+                        ),
+                        enabled: !_isSubmitting,
+                        validator: _numberValidator,
                       ),
-                      keyboardType: const TextInputType.numberWithOptions(
-                        signed: true,
-                        decimal: true,
-                      ),
-                      enabled: !_isSubmitting,
-                      validator: _numberValidator,
                     ),
                   ),
                   const SizedBox(width: 16),
                   Expanded(
-                    child: TextFormField(
-                      controller: _maxController,
-                      decoration: InputDecoration(
-                        labelText: 'Max °C',
-                        helperText: 'e.g. 30',
-                        // The cross-field "min must be < max" error is anchored
-                        // to this field rather than floating below the row.
-                        errorText:
-                            _fieldErrors[ThermostatValidationField.maxC] ??
-                            _rangeError,
+                    child: Semantics(
+                      label: 'Maximum temperature in degrees Celsius',
+                      child: TextFormField(
+                        controller: _maxController,
+                        decoration: InputDecoration(
+                          labelText: 'Max °C',
+                          helperText: 'e.g. 30',
+                          // The cross-field "min must be < max" error is anchored
+                          // to this field rather than floating below the row.
+                          errorText:
+                              _fieldErrors[ThermostatValidationField.maxC] ??
+                              _rangeError,
+                        ),
+                        keyboardType: const TextInputType.numberWithOptions(
+                          signed: true,
+                          decimal: true,
+                        ),
+                        enabled: !_isSubmitting,
+                        validator: _numberValidator,
                       ),
-                      keyboardType: const TextInputType.numberWithOptions(
-                        signed: true,
-                        decimal: true,
-                      ),
-                      enabled: !_isSubmitting,
-                      validator: _numberValidator,
                     ),
                   ),
                 ],

--- a/app/lib/features/thermostats/widgets/thermostat_history_chart.dart
+++ b/app/lib/features/thermostats/widgets/thermostat_history_chart.dart
@@ -11,19 +11,26 @@ class ThermostatHistoryChart extends StatelessWidget {
   const ThermostatHistoryChart({
     required this.samples,
     required this.range,
+    this.minC,
+    this.maxC,
     this.expand = false,
     super.key,
   });
 
   final List<TemperatureSample> samples;
   final ThermostatHistoryRange range;
+
+  /// The configured safe range; when provided, the chart draws threshold lines
+  /// and a shaded safe-zone band so excursions are obvious at a glance.
+  final double? minC;
+  final double? maxC;
   final bool expand;
 
   @override
   Widget build(BuildContext context) {
     if (samples.isEmpty) {
       return SizedBox(
-        height: 180,
+        height: 240,
         child: Center(
           child: Text(
             'No history available for this range yet.',
@@ -51,9 +58,31 @@ class ThermostatHistoryChart extends StatelessWidget {
     // Render continuous line; do not break segments (avoid visual gaps)
     final segmentedSpots = <List<FlSpot>>[spots];
 
-    final minY = sorted.map((s) => s.valueC).reduce(min);
-    final maxY = sorted.map((s) => s.valueC).reduce(max);
-    final padding = max(0.5, (maxY - minY).abs() * 0.1);
+    final scheme = Theme.of(context).colorScheme;
+    final dataMin = sorted.map((s) => s.valueC).reduce(min);
+    final dataMax = sorted.map((s) => s.valueC).reduce(max);
+    final padding = max(0.5, (dataMax - dataMin).abs() * 0.1);
+    final dataSpan = max(dataMax - dataMin, 0.5);
+
+    // Pull the safe-range bounds into view when they're close enough to the
+    // data that the trace's relationship to them matters — a very wide
+    // configured range must not squash the trace flat.
+    final lo = minC;
+    final hi = maxC;
+    var viewMin = dataMin - padding;
+    var viewMax = dataMax + padding;
+    if (lo != null &&
+        lo >= dataMin - dataSpan * 1.5 &&
+        lo - padding < viewMin) {
+      viewMin = lo - padding;
+    }
+    if (hi != null &&
+        hi <= dataMax + dataSpan * 1.5 &&
+        hi + padding > viewMax) {
+      viewMax = hi + padding;
+    }
+    final yInterval = _suggestedYInterval(viewMin, viewMax);
+    final tickDecimals = yInterval < 1 ? 1 : 0;
 
     final minX = spots.first.x;
     final maxX = spots.last.x;
@@ -63,16 +92,48 @@ class ThermostatHistoryChart extends StatelessWidget {
     final semanticsValue =
         'From ${semanticsFormatter.format(sorted.first.observedAt.toLocal())} '
         'to ${semanticsFormatter.format(sorted.last.observedAt.toLocal())}. '
-        'Temperatures ranged from ${minY.toStringAsFixed(1)} to '
-        '${maxY.toStringAsFixed(1)} degrees Celsius.';
+        'Temperatures ranged from ${dataMin.toStringAsFixed(1)} to '
+        '${dataMax.toStringAsFixed(1)} degrees Celsius.'
+        '${lo != null && hi != null ? ' Safe range ${lo.toStringAsFixed(1)} to ${hi.toStringAsFixed(1)} degrees Celsius.' : ''}';
+
+    HorizontalLine boundLine(double y, String label) => HorizontalLine(
+      y: y,
+      color: scheme.error.withValues(alpha: 0.7),
+      strokeWidth: 1.5,
+      dashArray: const [6, 4],
+      label: HorizontalLineLabel(
+        show: true,
+        alignment: Alignment.topRight,
+        style: Theme.of(
+          context,
+        ).textTheme.labelSmall?.copyWith(color: scheme.error),
+        labelResolver: (_) => label,
+      ),
+    );
 
     final chart = LineChart(
       LineChartData(
         minX: minX,
         maxX: maxX == minX ? maxX + 1 : maxX,
-        minY: minY - padding,
-        maxY: maxY + padding,
+        minY: viewMin,
+        maxY: viewMax,
         clipData: const FlClipData.all(),
+        rangeAnnotations: RangeAnnotations(
+          horizontalRangeAnnotations: [
+            if (lo != null && hi != null)
+              HorizontalRangeAnnotation(
+                y1: lo,
+                y2: hi,
+                color: scheme.primary.withValues(alpha: 0.06),
+              ),
+          ],
+        ),
+        extraLinesData: ExtraLinesData(
+          horizontalLines: [
+            if (lo != null) boundLine(lo, 'Min'),
+            if (hi != null) boundLine(hi, 'Max'),
+          ],
+        ),
         titlesData: FlTitlesData(
           topTitles: const AxisTitles(
             sideTitles: SideTitles(showTitles: false),
@@ -81,12 +142,19 @@ class ThermostatHistoryChart extends StatelessWidget {
             sideTitles: SideTitles(showTitles: false),
           ),
           leftTitles: AxisTitles(
+            axisNameSize: 18,
+            axisNameWidget: Text(
+              '°C',
+              style: Theme.of(
+                context,
+              ).textTheme.labelSmall?.copyWith(color: scheme.onSurfaceVariant),
+            ),
             sideTitles: SideTitles(
               showTitles: true,
-              reservedSize: 48,
-              interval: _suggestedYInterval(minY, maxY),
+              reservedSize: 40,
+              interval: yInterval,
               getTitlesWidget: (value, meta) => Text(
-                value.toStringAsFixed(2),
+                value.toStringAsFixed(tickDecimals),
                 style: Theme.of(context).textTheme.bodySmall,
               ),
             ),
@@ -113,19 +181,22 @@ class ThermostatHistoryChart extends StatelessWidget {
         gridData: FlGridData(
           show: true,
           drawVerticalLine: false,
-          horizontalInterval: _suggestedYInterval(minY, maxY),
+          horizontalInterval: yInterval,
         ),
         lineTouchData: LineTouchData(
           touchTooltipData: LineTouchTooltipData(
-            getTooltipColor: (_) =>
-                Theme.of(context).colorScheme.surfaceContainerHighest,
+            getTooltipColor: (_) => scheme.surfaceContainerHighest,
             getTooltipItems: (touchedSpots) {
               final formatter = _detailedFormatterForRange(range);
+              final style = Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: scheme.onSurface,
+                fontWeight: FontWeight.w600,
+              );
               return touchedSpots.map((spot) {
                 final timestamp = base.add(Duration(seconds: spot.x.toInt()));
                 return LineTooltipItem(
-                  '${spot.y.toStringAsFixed(2)}°C\n${formatter.format(timestamp.toLocal())}',
-                  Theme.of(context).textTheme.bodyMedium!,
+                  '${spot.y.toStringAsFixed(1)}°C\n${formatter.format(timestamp.toLocal())}',
+                  style ?? const TextStyle(),
                 );
               }).toList();
             },

--- a/app/test/unit/format_helpers_test.dart
+++ b/app/test/unit/format_helpers_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:farmctl/core/format/error_messages.dart';
+import 'package:farmctl/core/format/relative_time.dart';
+import 'package:farmctl/core/format/semantics_text.dart';
+
+void main() {
+  group('humanizeError', () {
+    test('maps connectivity failures to a friendly message', () {
+      expect(
+        humanizeError(Exception('SocketException: Failed host lookup')),
+        contains("Couldn't reach the server"),
+      );
+      expect(
+        humanizeError('Connection closed'),
+        contains("Couldn't reach the server"),
+      );
+    });
+
+    test('maps timeouts, auth, rate-limit and server errors', () {
+      expect(humanizeError('Request timed out'), contains('timed out'));
+      expect(humanizeError('HTTP 401 Unauthorized'), contains('GitHub token'));
+      expect(humanizeError('429 rate limit'), contains('Rate limit'));
+      expect(
+        humanizeError('500 server error'),
+        contains('server had a problem'),
+      );
+    });
+
+    test('maps parse problems and falls back generically', () {
+      expect(
+        humanizeError('FormatException: unexpected token'),
+        contains("couldn't be read"),
+      );
+      expect(humanizeError(null), contains('Something went wrong'));
+      expect(humanizeError('totally opaque'), contains('Something went wrong'));
+    });
+  });
+
+  group('formatRelativeDuration', () {
+    test('describes recent and older spans', () {
+      expect(formatRelativeDuration(const Duration(seconds: 30)), 'just now');
+      expect(formatRelativeDuration(const Duration(minutes: 1)), '1 min ago');
+      expect(formatRelativeDuration(const Duration(minutes: 5)), '5 mins ago');
+      expect(formatRelativeDuration(const Duration(hours: 1)), '1 hour ago');
+      expect(formatRelativeDuration(const Duration(hours: 3)), '3 hours ago');
+      expect(formatRelativeDuration(const Duration(days: 2)), '2 days ago');
+    });
+  });
+
+  group('formatElapsed', () {
+    test('describes an out-of-range span without an "ago" suffix', () {
+      expect(formatElapsed(const Duration(seconds: 30)), 'less than a minute');
+      expect(formatElapsed(const Duration(minutes: 1)), '1 minute');
+      expect(formatElapsed(const Duration(minutes: 45)), '45 minutes');
+      expect(
+        formatElapsed(const Duration(hours: 2, minutes: 14)),
+        '2 hours 14 min',
+      );
+      expect(formatElapsed(const Duration(hours: 3)), '3 hours');
+      expect(formatElapsed(const Duration(days: 1, hours: 2)), '1 day 2 h');
+      expect(formatElapsed(const Duration(days: 2)), '2 days');
+    });
+  });
+
+  group('spokenText', () {
+    test('expands units and separators for screen readers', () {
+      expect(spokenText('21.5°C'), '21.5 degrees Celsius');
+      expect(
+        spokenText('Out of range • 25°C'),
+        'Out of range . 25 degrees Celsius',
+      );
+      expect(spokenText('10 – 20'), '10 to 20');
+    });
+  });
+}

--- a/app/test/unit/thermostat_status_presentation_test.dart
+++ b/app/test/unit/thermostat_status_presentation_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:farmctl/features/thermostats/models/thermostat_state.dart';
+import 'package:farmctl/features/thermostats/models/thermostat_status_presentation.dart';
+
+void main() {
+  final now = DateTime.utc(2025, 1, 1, 12);
+
+  ThermostatState state(ThermostatReadingStatus status, {double? value}) {
+    return ThermostatState(
+      thermostatId: 't1',
+      status: status,
+      lastValueC: value,
+      lastFetchedAt: now.subtract(const Duration(minutes: 5)),
+      createdAt: now,
+      updatedAt: now,
+    );
+  }
+
+  ThermostatStatusPresentation present(ThermostatReadingStatus status) =>
+      ThermostatStatusPresentation.fromState(
+        state(status, value: 12),
+        now: now,
+      );
+
+  test('awaiting state is neutral, not an alarm', () {
+    final p = ThermostatStatusPresentation.fromState(null, now: now);
+    expect(p.severity, ThermostatStatusSeverity.neutral);
+    expect(p.label, 'Awaiting');
+    expect(p.icon, Icons.hourglass_empty);
+    expect(p.isDanger, isFalse);
+    expect(p.isProblem, isFalse);
+  });
+
+  test('ok reading is in range and not a problem', () {
+    final p = present(ThermostatReadingStatus.ok);
+    expect(p.severity, ThermostatStatusSeverity.ok);
+    expect(p.label, 'In range');
+    expect(p.icon, Icons.check_circle);
+    expect(p.isDanger, isFalse);
+    expect(p.isProblem, isFalse);
+  });
+
+  test('out of range is the only danger state', () {
+    final p = present(ThermostatReadingStatus.outOfRange);
+    expect(p.severity, ThermostatStatusSeverity.danger);
+    expect(p.label, 'Out of range');
+    expect(p.icon, Icons.warning_amber_rounded);
+    expect(p.isDanger, isTrue);
+  });
+
+  test('network error is offline, not danger', () {
+    final p = present(ThermostatReadingStatus.networkError);
+    expect(p.severity, ThermostatStatusSeverity.offline);
+    expect(p.label, 'Offline');
+    expect(p.icon, Icons.cloud_off);
+    expect(
+      p.isDanger,
+      isFalse,
+      reason: 'a wifi blip is not a temperature alarm',
+    );
+    expect(p.isProblem, isTrue);
+  });
+
+  test('http/parse/unknown are warnings with distinct labels', () {
+    expect(present(ThermostatReadingStatus.httpError).label, 'Server error');
+    expect(present(ThermostatReadingStatus.parseError).label, 'Bad data');
+    expect(present(ThermostatReadingStatus.unknown).label, 'Unknown');
+    for (final s in const [
+      ThermostatReadingStatus.httpError,
+      ThermostatReadingStatus.parseError,
+      ThermostatReadingStatus.unknown,
+    ]) {
+      expect(present(s).severity, ThermostatStatusSeverity.warning);
+      expect(present(s).isDanger, isFalse);
+    }
+  });
+
+  test('color distinguishes danger from offline', () {
+    const scheme = ColorScheme.light();
+    expect(
+      present(ThermostatReadingStatus.outOfRange).color(scheme),
+      scheme.error,
+    );
+    expect(
+      present(ThermostatReadingStatus.networkError).color(scheme),
+      scheme.onSurfaceVariant,
+    );
+    expect(present(ThermostatReadingStatus.ok).color(scheme), scheme.primary);
+  });
+}

--- a/app/test/widget/alarm_fullscreen_page_test.dart
+++ b/app/test/widget/alarm_fullscreen_page_test.dart
@@ -58,9 +58,10 @@ void main() {
     await pumpPage(tester);
 
     expect(find.text('Greenhouse'), findsOneWidget);
-    expect(find.text('25.20°C'), findsOneWidget);
-    expect(find.text('Snooze 5 min'), findsOneWidget);
-    expect(find.text('Dismiss'), findsOneWidget);
+    expect(find.text('25.2°C'), findsOneWidget);
+    expect(find.text('Snooze 5 minutes'), findsOneWidget);
+    // "Acknowledge" stops the alarm but leaves monitoring armed.
+    expect(find.text('Acknowledge'), findsOneWidget);
   });
 
   testWidgets(
@@ -107,7 +108,7 @@ void main() {
     tester,
   ) async {
     await pumpStream(tester, Stream<ThermostatSummary?>.value(null));
-    expect(find.text('Thermostat not found.'), findsOneWidget);
+    expect(find.textContaining('Thermostat not found'), findsOneWidget);
   });
 
   testWidgets('shows an error message when the summary stream fails', (
@@ -117,7 +118,7 @@ void main() {
       tester,
       Stream<ThermostatSummary?>.error(Exception('boom')),
     );
-    expect(find.textContaining('Failed to load alarm details'), findsOneWidget);
+    expect(find.textContaining('Something went wrong'), findsOneWidget);
   });
 
   testWidgets('surfaces snooze and silence status details', (tester) async {
@@ -142,13 +143,13 @@ void main() {
 
     expect(find.textContaining('Snoozed until'), findsOneWidget);
     expect(
-      find.text('Silenced until reading returns to range.'),
+      find.text('Silenced until the reading returns to range.'),
       findsOneWidget,
     );
-    // The "Silence until OK" action is disabled while already silenced.
+    // The silence action is disabled while already silenced.
     final silenceButton = tester.widget<OutlinedButton>(
       find.ancestor(
-        of: find.text('Silence until OK'),
+        of: find.text('Silence until back in range'),
         matching: find.byType(OutlinedButton),
       ),
     );

--- a/app/test/widget/thermostat_card_test.dart
+++ b/app/test/widget/thermostat_card_test.dart
@@ -94,8 +94,10 @@ void main() {
 
     expect(find.text('--°C'), findsOneWidget);
     expect(find.text('Awaiting first reading'), findsOneWidget);
-    expect(find.text('No successful readings yet.'), findsOneWidget);
-    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+    expect(find.textContaining('No successful readings'), findsOneWidget);
+    // Neutral, non-alarm status glyph while awaiting data.
+    expect(find.byIcon(Icons.hourglass_empty), findsOneWidget);
+    expect(find.byIcon(Icons.check_circle), findsNothing);
   });
 
   testWidgets('shows the alert treatment when out of range', (tester) async {
@@ -109,27 +111,31 @@ void main() {
       ),
     );
 
-    expect(find.byIcon(Icons.warning_rounded), findsOneWidget);
+    // Out-of-range is the loud danger state with its own filled warning glyph.
+    expect(find.byIcon(Icons.warning_amber_rounded), findsOneWidget);
     expect(find.byIcon(Icons.check_circle), findsNothing);
     expect(find.textContaining('Out of range'), findsWidgets);
   });
 
-  testWidgets('every error status renders as an alert', (tester) async {
-    for (final status in const [
-      ThermostatReadingStatus.networkError,
-      ThermostatReadingStatus.httpError,
-      ThermostatReadingStatus.parseError,
-      ThermostatReadingStatus.unknown,
-    ]) {
+  testWidgets('each status renders a distinct, non-ok glyph', (tester) async {
+    const expectedIcon = <ThermostatReadingStatus, IconData>{
+      ThermostatReadingStatus.networkError: Icons.cloud_off,
+      ThermostatReadingStatus.httpError: Icons.error_outline,
+      ThermostatReadingStatus.parseError: Icons.error_outline,
+      ThermostatReadingStatus.unknown: Icons.help_outline,
+    };
+    for (final entry in expectedIcon.entries) {
       await _pump(
         tester,
-        _summary(status: status, value: 12.0, fetchedAt: recent),
+        _summary(status: entry.key, value: 12.0, fetchedAt: recent),
       );
       expect(
-        find.byIcon(Icons.warning_rounded),
+        find.byIcon(entry.value),
         findsOneWidget,
-        reason: '$status should be an alert',
+        reason: '${entry.key} should show ${entry.value}',
       );
+      // A connectivity/server problem must NOT look like a healthy reading.
+      expect(find.byIcon(Icons.check_circle), findsNothing);
     }
   });
 

--- a/app/test/widget/thermostat_detail_page_test.dart
+++ b/app/test/widget/thermostat_detail_page_test.dart
@@ -105,7 +105,7 @@ void main() {
   ) async {
     await _pump(tester, summary: null);
 
-    expect(find.text('Thermostat not found.'), findsOneWidget);
+    expect(find.text('Thermostat not found'), findsOneWidget);
     expect(find.byType(ThermostatCard), findsNothing);
   });
 
@@ -118,7 +118,7 @@ void main() {
       history: Stream<List<TemperatureSample>>.error(Exception('boom')),
     );
 
-    expect(find.text('Unable to load history.'), findsOneWidget);
+    expect(find.text('Unable to load history'), findsOneWidget);
   });
 
   testWidgets('switches the range and refreshes history', (tester) async {

--- a/app/test/widget/thermostat_form_dialog_test.dart
+++ b/app/test/widget/thermostat_form_dialog_test.dart
@@ -194,6 +194,34 @@ void main() {
     expect(find.text('Test & Save'), findsNothing);
   });
 
+  testWidgets('save-without-testing persists edits made after the failure', (
+    tester,
+  ) async {
+    ThermostatDraft? savedWithoutTest;
+    await _openDialog(
+      tester,
+      onSubmit: (_) async => throw const ThermostatFetchException(
+        status: ThermostatReadingStatus.networkError,
+        message: 'No signal.',
+      ),
+      onSaveWithoutTest: (draft) async {
+        savedWithoutTest = draft;
+        return _dummy();
+      },
+    );
+    await _fillValid(tester); // min 0
+    await tester.tap(find.text('Test & Save'));
+    await tester.pumpAndSettle();
+
+    // Correct the minimum AFTER the test failed, then save without testing.
+    await tester.enterText(find.byType(TextFormField).at(2), '5');
+    await tester.tap(find.text('Save without testing'));
+    await tester.pumpAndSettle();
+
+    // The current field value is saved, not the stale pre-failure snapshot.
+    expect(savedWithoutTest!.minC, 5);
+  });
+
   testWidgets('pre-fills the fields when editing', (tester) async {
     await _openDialog(
       tester,

--- a/app/test/widget/thermostat_form_dialog_test.dart
+++ b/app/test/widget/thermostat_form_dialog_test.dart
@@ -24,6 +24,7 @@ Thermostat _dummy() {
 Future<void> _openDialog(
   WidgetTester tester, {
   required Future<Thermostat> Function(ThermostatDraft draft) onSubmit,
+  Future<Thermostat> Function(ThermostatDraft draft)? onSaveWithoutTest,
   Thermostat? initial,
 }) async {
   await tester.pumpWidget(
@@ -34,8 +35,11 @@ Future<void> _openDialog(
             child: TextButton(
               onPressed: () => showDialog<Thermostat>(
                 context: context,
-                builder: (_) =>
-                    ThermostatFormDialog(onSubmit: onSubmit, initial: initial),
+                builder: (_) => ThermostatFormDialog(
+                  onSubmit: onSubmit,
+                  onSaveWithoutTest: onSaveWithoutTest,
+                  initial: initial,
+                ),
               ),
               child: const Text('open'),
             ),
@@ -157,6 +161,39 @@ void main() {
     expect(find.text('Test & Save'), findsOneWidget); // still open
   });
 
+  testWidgets('offers "Save without testing" when the test fetch fails', (
+    tester,
+  ) async {
+    ThermostatDraft? savedWithoutTest;
+    await _openDialog(
+      tester,
+      onSubmit: (_) async => throw const ThermostatFetchException(
+        status: ThermostatReadingStatus.networkError,
+        message: 'No signal right now.',
+      ),
+      onSaveWithoutTest: (draft) async {
+        savedWithoutTest = draft;
+        return _dummy();
+      },
+    );
+    await _fillValid(tester);
+
+    await tester.tap(find.text('Test & Save'));
+    await tester.pumpAndSettle();
+
+    // The fetch error is shown with an escape hatch.
+    expect(find.text('No signal right now.'), findsOneWidget);
+    expect(find.text('Save without testing'), findsOneWidget);
+
+    await tester.tap(find.text('Save without testing'));
+    await tester.pumpAndSettle();
+
+    expect(savedWithoutTest, isNotNull);
+    expect(savedWithoutTest!.name, 'Barn');
+    // Dialog closed after saving.
+    expect(find.text('Test & Save'), findsNothing);
+  });
+
   testWidgets('pre-fills the fields when editing', (tester) async {
     await _openDialog(
       tester,
@@ -166,7 +203,8 @@ void main() {
 
     expect(find.text('Edit thermostat'), findsOneWidget);
     expect(find.text('Barn'), findsOneWidget);
-    expect(find.text('0.00'), findsOneWidget);
-    expect(find.text('20.00'), findsOneWidget);
+    // Integer bounds are shown without trailing zeros.
+    expect(find.text('0'), findsOneWidget);
+    expect(find.text('20'), findsOneWidget);
   });
 }

--- a/app/test/widget/thermostats_page_interaction_test.dart
+++ b/app/test/widget/thermostats_page_interaction_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:farmctl/features/settings/data/alert_config_repository.dart';
 import 'package:farmctl/features/settings/data/secure_token_store.dart';
+import 'package:farmctl/features/settings/models/alert_config.dart';
 import 'package:farmctl/features/settings/providers/settings_providers.dart';
 import 'package:farmctl/features/thermostats/data/thermostat_client.dart';
 import 'package:farmctl/features/thermostats/data/thermostat_database.dart';
@@ -104,6 +105,20 @@ Future<ThermostatDatabase> _pumpPage(
             tokenStore: _NoopTokenStore(),
           ),
         ),
+        // Plain stream for the pause banner avoids a Drift watch-stream timer.
+        alertConfigProvider.overrideWith(
+          (ref) => Stream.value(
+            const AlertConfig(
+              pollInterval: Duration(minutes: 5),
+              exactAlarmsEnabled: false,
+              soundUri: null,
+              vibrate: true,
+              volumeBoost: false,
+              pauseAllUntil: null,
+              githubToken: null,
+            ),
+          ),
+        ),
         thermostatsProvider.overrideWith((ref) => Stream.value(rendered)),
         offlineStatusProvider.overrideWithValue(OfflineStatus.online),
       ],
@@ -119,7 +134,9 @@ void main() {
     final db = await _pumpPage(tester, rendered: const []);
     expect(find.byType(ThermostatCard), findsNothing);
 
-    await tester.tap(find.text('Add thermostat'));
+    await tester.tap(
+      find.widgetWithText(FloatingActionButton, 'Add thermostat'),
+    );
     await tester.pumpAndSettle();
 
     await tester.enterText(find.byType(TextFormField).at(0), 'Greenhouse');
@@ -129,7 +146,7 @@ void main() {
     await tester.tap(find.text('Test & Save'));
     await tester.pumpAndSettle();
 
-    expect(find.text('Thermostat added.'), findsOneWidget);
+    expect(find.text('Thermostat added'), findsOneWidget);
     expect(await db.listThermostats(), hasLength(1));
   });
 
@@ -158,7 +175,7 @@ void main() {
     await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
     await tester.pumpAndSettle();
 
-    expect(find.text('Thermostat deleted.'), findsOneWidget);
+    expect(find.text('Thermostat deleted'), findsOneWidget);
     expect(await db.getThermostat('t1'), isNull);
   });
 
@@ -186,7 +203,7 @@ void main() {
     await tester.tap(find.text('Test & Save'));
     await tester.pumpAndSettle();
 
-    expect(find.text('Thermostat updated.'), findsOneWidget);
+    expect(find.text('Thermostat updated'), findsOneWidget);
     expect((await db.getThermostat('t1'))?.name, 'Polytunnel');
   });
 

--- a/app/test/widget/thermostats_page_test.dart
+++ b/app/test/widget/thermostats_page_test.dart
@@ -2,11 +2,23 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:farmctl/features/settings/models/alert_config.dart';
+import 'package:farmctl/features/settings/providers/settings_providers.dart';
 import 'package:farmctl/features/thermostats/models/thermostat.dart';
 import 'package:farmctl/features/thermostats/models/thermostat_state.dart';
 import 'package:farmctl/features/thermostats/providers/thermostat_providers.dart';
 import 'package:farmctl/features/thermostats/view/thermostats_page.dart';
 import 'package:farmctl/features/thermostats/widgets/thermostat_card.dart';
+
+const _defaultConfig = AlertConfig(
+  pollInterval: Duration(minutes: 5),
+  exactAlarmsEnabled: false,
+  soundUri: null,
+  vibrate: true,
+  volumeBoost: false,
+  pauseAllUntil: null,
+  githubToken: null,
+);
 
 ThermostatSummary _summary(String id, String name) {
   final timestamp = DateTime.utc(2025, 1, 1, 12);
@@ -37,6 +49,7 @@ Future<void> _pump(
   WidgetTester tester, {
   required Stream<List<ThermostatSummary>> thermostats,
   OfflineStatus offline = OfflineStatus.online,
+  AlertConfig config = _defaultConfig,
 }) async {
   // Narrow, tall surface so the layout uses the single-column scrolling list
   // (the wide multi-column grid constrains card height and overflows in tests).
@@ -51,6 +64,9 @@ Future<void> _pump(
         thermostatsProvider.overrideWith((ref) => thermostats),
         // Override so the provider's periodic re-eval timer isn't started.
         offlineStatusProvider.overrideWithValue(offline),
+        // Plain stream avoids a Drift watch-stream pending timer for the pause
+        // banner.
+        alertConfigProvider.overrideWith((ref) => Stream.value(config)),
       ],
       child: const MaterialApp(home: ThermostatsPage()),
     ),
@@ -63,7 +79,8 @@ void main() {
     await _pump(tester, thermostats: Stream.value(const <ThermostatSummary>[]));
 
     expect(find.text('No thermostats yet'), findsOneWidget);
-    expect(find.text('Add thermostat'), findsOneWidget);
+    // Both the empty-state CTA and the FAB offer "Add thermostat".
+    expect(find.text('Add thermostat'), findsWidgets);
     expect(find.byType(ThermostatCard), findsNothing);
   });
 
@@ -90,7 +107,7 @@ void main() {
     );
     await tester.pump();
 
-    expect(find.text('Failed to load thermostats.'), findsOneWidget);
+    expect(find.text('Failed to load thermostats'), findsOneWidget);
   });
 
   testWidgets('shows the offline banner when offline', (tester) async {
@@ -127,5 +144,35 @@ void main() {
 
     expect(find.text('Offline mode'), findsNothing);
     expect(find.text('Connectivity issues'), findsNothing);
+  });
+
+  testWidgets('surfaces a pause banner with a Resume action while paused', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      thermostats: Stream.value([_summary('t1', 'Greenhouse')]),
+      config: AlertConfig(
+        pollInterval: const Duration(minutes: 5),
+        exactAlarmsEnabled: false,
+        soundUri: null,
+        vibrate: true,
+        volumeBoost: false,
+        pauseAllUntil: DateTime.now().toUtc().add(const Duration(hours: 2)),
+        githubToken: null,
+      ),
+    );
+
+    expect(find.text('Monitoring paused'), findsOneWidget);
+    expect(find.widgetWithText(TextButton, 'Resume'), findsOneWidget);
+  });
+
+  testWidgets('hides the pause banner when not paused', (tester) async {
+    await _pump(
+      tester,
+      thermostats: Stream.value([_summary('t1', 'Greenhouse')]),
+    );
+
+    expect(find.text('Monitoring paused'), findsNothing);
   });
 }

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -1,16 +1,31 @@
 import 'package:drift/native.dart';
 import 'package:farmctl/app.dart';
+import 'package:farmctl/features/settings/models/alert_config.dart';
+import 'package:farmctl/features/settings/providers/settings_providers.dart';
 import 'package:farmctl/features/thermostats/data/thermostat_database.dart';
 import 'package:farmctl/features/thermostats/providers/thermostat_providers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+const _defaultConfig = AlertConfig(
+  pollInterval: Duration(minutes: 5),
+  exactAlarmsEnabled: false,
+  soundUri: null,
+  vibrate: true,
+  volumeBoost: false,
+  pauseAllUntil: null,
+  githubToken: null,
+);
+
 Widget buildApp(ThermostatDatabase database) {
   return ProviderScope(
     overrides: [
       thermostatDatabaseProvider.overrideWithValue(database),
       thermostatsProvider.overrideWith((ref) => const Stream.empty()),
+      // Plain stream avoids a Drift watch-stream subscription (and its pending
+      // dispose timer) for the new pause banner on the thermostats page.
+      alertConfigProvider.overrideWith((ref) => Stream.value(_defaultConfig)),
     ],
     child: const FarmCtlApp(),
   );


### PR DESCRIPTION
Implements the full set of findings from the comprehensive UX review, across every screen. Per the agreed scope: fix everything; alarm "Dismiss" → "Acknowledge (stays armed)"; leave the Gist-ID field as-is; delete gets Undo + an error-tinted button.

## Safety-critical alarm screen
- `liveRegion` Semantics + spoken °C so the danger (which thermostat, current temp, safe range, elapsed time) is announced to screen readers — the screen previously had none.
- **"Acknowledge" replaces the unguarded "Dismiss"**: it stops the current alert but leaves monitoring armed (re-alerts if still out of range); full-silence stays a separate, clearly-labelled action.
- Full-width ≥52dp stacked actions ordered by escalation; tooltip on the disabled silence button; shows how long the reading has been out of range; scrolls instead of overflowing at large text scale.

## Status clarity & charts
- Per-status icon + word + colour so an out-of-range temperature (danger, red) is distinct from a connectivity blip (offline, muted) — no more red/green binary, and the card hero only reddens for a real temperature problem.
- History chart draws the min/max safe-range band + threshold lines; 1-dp axis with a °C label; consistent state heights; staleness cue on the card timestamp.

## Recovery & flows
- Thermostats list: pull-to-refresh, Retry on error, empty-state CTA, **app-wide pause banner with Resume** (the paused state was previously invisible here), delete **Undo** (8s) + error-tinted Delete.
- Detail "not found" gets a "Back to thermostats" escape and hides the meaningless refresh; inline history Retry; shared history-range state across detail ⇄ full-screen; no more forced device orientation; branded 404 route.
- Humanised, consistently-styled error copy everywhere (no raw exception dumps).

## Settings & forms
- Honest sub-15-min cadence note; poll-interval and test-alarm confirmations; GitHub-token "optional, leave blank" explainer + plain-language test result.
- Min/Max inline validators + hints + range error anchored to the field; **"Save without testing"** fallback for patchy signal; trailing `.00` stripped; name length counter.

## Tests & review
- New shared helpers (semantics text, relative/elapsed time, error humaniser, status-presentation model) with unit tests; updated widget tests for the new behaviour; added pause-banner, save-without-test, and status-model tests. **205 tests green, coverage 72.25%.**
- Two review agents (correctness + a11y/safety) and a validator pass; fixed the real findings (form stale-draft save, 8s Undo, semantics double-reads, error-mapping order). The alarm announce-on-mount relies on `liveRegion` (reliable on the target Android platform) rather than a periodic ticker, which would destabilise the existing `pumpAndSettle` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)