### PR TITLE
Replace WorkManager+AlarmManager with a foreground service for reliable background monitoring

### DIFF
--- a/.agent/ExecPlan-BackgroundReliability.md
+++ b/.agent/ExecPlan-BackgroundReliability.md
@@ -68,7 +68,28 @@ Recommend testing on the reporter's Pixel 9 before relying on it:
 - ✅ Confirmed `flutter_foreground_task` v9.2.2 API (fetched real source: task
   handler signatures, `ForegroundTaskOptions`, `specialUse` service type,
   Android 15 restrictions) directly from the plugin's GitHub repo.
-- ☐ Implement scheduler swap, manifest/gradle changes, Settings UI cleanup,
-  DB migration.
-- ☐ Update/extend unit + widget tests; run `build_runner`, `analyze`, `test`.
-- ☐ Code review pass.
+- ✅ Implemented scheduler swap, manifest/gradle changes, Settings UI cleanup,
+  DB migration (v8 -> v9, drops `exact_alarms_enabled`).
+- ✅ Updated/extended unit + widget tests; `build_runner`, `analyze`, `test`
+  (211/211) all green; coverage 72.75% (threshold 70%); `dart format` clean.
+- ✅ Two independent review passes (scheduler correctness; Android
+  manifest/plugin-API correctness against the real v9.2.2 source):
+  - **Fixed**: `onStart` + `onRepeatEvent` (the only two callers of
+    `_runMonitorTask`, both in the foreground service's own isolate) could
+    both pass the DB-backed debounce check before either wrote
+    `lastMonitorRunAt` back (check-then-write across separate `await`s),
+    letting two runs execute concurrently. Closed with a synchronous
+    in-isolate lock (`_monitorRunInProgress`) around `_runMonitorTask`,
+    which can't race the same way since the check-and-set has no `await`
+    between them. The DB-backed debounce is kept as a secondary safety net.
+  - **No other real bugs found.** Manifest/service declaration, permissions,
+    and every `flutter_foreground_task` call site were verified against the
+    plugin's actual v9.2.2 source (not training-data assumptions).
+  - **Open, non-blocking nit**: `compileSdk = flutter.compileSdkVersion` is
+    auto-resolved from the Flutter SDK; if the developer's installed Flutter
+    version resolves a `compileSdkVersion` below 35, the Gradle build would
+    fail (`targetSdk > compileSdk`). Not introduced by this change (the app
+    already relied on `flutter.compileSdkVersion` before), but worth a
+    one-line `flutter --version` sanity check when building for real.
+- ☐ Manual verification on the reporter's Pixel 9 (see the limitation note
+  above) — could not be done in this sandboxed session.

--- a/.agent/ExecPlan-BackgroundReliability.md
+++ b/.agent/ExecPlan-BackgroundReliability.md
@@ -1,0 +1,74 @@
+# 🧩 ExecPlan — Background Monitoring Reliability (Pixel 9 / Android 15+)
+
+## 🎯 Purpose
+User report: the background monitoring watchdog fails to run reliably on a
+Pixel 9. This resolves the ExecPlan.md "Gate A" decision (Flutter-only vs.
+minimal native shim) by adopting a true Android **Foreground Service**
+(`flutter_foreground_task`), which is exempt from Doze/App Standby deferral
+while alive — unlike the previous `WorkManager` (15-min floor, still
+Doze-deferrable) + `android_alarm_manager_plus` (exact-alarm permission
+dependent) combination.
+
+## 🧱 Scope
+- In scope: background scheduler architecture, targetSdk bump (34 → 35),
+  Settings UI cleanup for the retired exact-alarm toggle, DB migration to
+  drop the now-unused `exact_alarms_enabled` column.
+- Out of scope: alarm UX changes, new Settings features, iOS (not supported).
+
+## 🧭 Decision Log
+- **Foreground-service plugin over a hand-rolled native shim** — user chose
+  this explicitly (`flutter_foreground_task`) over writing a bespoke Kotlin
+  service. No native code to maintain; matches the ExecPlan's original
+  Flutter-first preference.
+- **`specialUse` foreground service type**, not `dataSync` — `dataSync` caps
+  at 6h/24h on Android 15 and can't be launched from `BOOT_COMPLETED` on
+  Android 15+; `specialUse` has neither restriction. The app is sideloaded
+  (GitHub release APK, not Play Store), so `specialUse`'s Play Console
+  review requirement for the subtype string doesn't block distribution.
+- **Single scheduler as source of truth.** The live foreground service now
+  drives every poll (`onRepeatEvent` at the user's configured interval, down
+  to 1 minute, no 15-min floor, no exact-alarm permission needed).
+  `android_alarm_manager_plus` and its one-shot self-reschedule chain are
+  removed entirely — keeping it alongside a live service would double-poll
+  (both independently reschedule at the same nominal interval, drifting
+  apart and roughly doubling GitHub API calls). `workmanager` is demoted
+  from "run the full monitor" to a **watchdog**: fixed 15-minute floor,
+  restarts the foreground service if it isn't running, never fetches itself.
+  This directly resolves the M-1/M-2 findings from `.agent/code-review-2026-06-27.md`
+  (dual-scheduler race, non-exact fallback silently missing intervals)
+  by deletion rather than further patching.
+- **Removed the "Allow exact alarms" Settings toggle** and its permission
+  flow — nothing schedules via `AlarmManager` anymore, so the toggle would be
+  dead UI. Kept the "Allow background activity" (ignore battery
+  optimizations) button — still relevant since Android can still restrict
+  service starts/notifications for a non-exempt app.
+- **DB migration v8 → v9** drops `exact_alarms_enabled` from
+  `alert_config_entries` (`ALTER TABLE ... DROP COLUMN`, supported by the
+  bundled SQLite). Left as a real migration rather than an inert unused
+  field, per repo convention of not carrying dead code/columns.
+
+## ⚠️ Known limitation of this session
+No physical device or Android emulator is available in this sandboxed
+environment (network policy also blocks the Android SDK/emulator images).
+All Dart-level logic is covered by `flutter analyze` + `flutter test`
+(including new migration/unit tests), but the actual foreground-service
+lifecycle (persistent notification, boot restart, Doze exemption, OEM
+kill-and-restart behavior) has **not** been verified on real hardware.
+Recommend testing on the reporter's Pixel 9 before relying on it:
+1. Grant "Allow background activity" in Settings.
+2. Confirm the persistent "FarmCtl monitoring" notification appears and
+   survives screen-off for an extended period (30+ min).
+3. Reboot the device and confirm the notification/service comes back.
+4. Force-stop the app from Android system settings and confirm the
+   15-minute WorkManager watchdog brings the service back.
+
+## 📈 Progress
+- ✅ Investigated current dual-scheduler implementation and prior code-review
+  findings (`.agent/code-review-2026-06-27.md`, `.agent/ExecPlan.md` Gate A).
+- ✅ Confirmed `flutter_foreground_task` v9.2.2 API (fetched real source: task
+  handler signatures, `ForegroundTaskOptions`, `specialUse` service type,
+  Android 15 restrictions) directly from the plugin's GitHub repo.
+- ☐ Implement scheduler swap, manifest/gradle changes, Settings UI cleanup,
+  DB migration.
+- ☐ Update/extend unit + widget tests; run `build_runner`, `analyze`, `test`.
+- ☐ Code review pass.

--- a/.agent/ExecPlan-BackgroundReliability.md
+++ b/.agent/ExecPlan-BackgroundReliability.md
@@ -91,5 +91,55 @@ Recommend testing on the reporter's Pixel 9 before relying on it:
     fail (`targetSdk > compileSdk`). Not introduced by this change (the app
     already relied on `flutter.compileSdkVersion` before), but worth a
     one-line `flutter --version` sanity check when building for real.
+- ✅ Full "reviewer + skeptic" pass: 7 independent finder agents (line-by-line,
+  removed-behavior, cross-file tracing, reuse, simplification, efficiency,
+  altitude, CLAUDE.md/AGENTS.md conventions) plus a skeptic verifier on the
+  fixes themselves.
+  - **Fixed**: duplicated `ForegroundTaskOptions` construction between
+    `init()`/`updateService()` extracted into one `_foregroundTaskOptions()`
+    helper; `FlutterForegroundTask.init()` no longer runs on every call when
+    the service is already running (only needed on the cold-start path —
+    verified against the real plugin source that `updateService()`/
+    `isRunningService` never read `init()`-populated static state); the
+    `thermostatMonitorTask`/`thermostatMonitorUniqueName` constants (now
+    watchdog-only) renamed to `thermostatWatchdogTask`/
+    `thermostatWatchdogUniqueName` for clarity (string *values* unchanged, so
+    WorkManager still targets the same persisted periodic work on upgrade);
+    stale comment referencing "WorkManager retry backoff" (no longer
+    applicable — the watchdog doesn't call `_runMonitorTask`) rewritten;
+    added a comment on `_runWatchdogTask` explaining why it isn't redundant
+    with the plugin's own `allowAutoRestart`/`autoRunOnBoot` (it survives an
+    OEM process kill, which those don't — the actual Pixel 9 failure mode).
+  - **Declined, with rationale**: merging the 3 "open DB → load config →
+    close" sites (`initializeBackgroundMonitoring`, `_runWatchdogTask`,
+    `_runMonitorTaskLocked`) into one shared helper — on inspection they have
+    genuinely different, intentional error-handling shapes (swallow-and-close
+    vs. propagate-and-close vs. swallow-and-keep-open for the rest of the
+    run), so a shared helper would need parameters for each axis and not
+    actually reduce complexity. Removing the WorkManager watchdog in favor of
+    the plugin's native restart-only mechanisms — it's the only thing that
+    survives an OEM battery-manager process kill (see the new code comment).
+    Making pause immediately drop the service's tick cadence to the pause end
+    — real but low-severity (a few extra cheap DB reads per tick during a
+    pause window, no missed/incorrect behavior); would need to touch
+    pause-start/resume/duration-change call sites for a UX-only, non-bug win.
+    Escalating repeated `_runMonitorTask` failures beyond a debug log — a
+    genuine observability gap (a permanently-failing DB wouldn't get any
+    watchdog attention since `isRunningService` stays true) but is a new
+    diagnostics feature, not a bug fix, out of scope for this pass.
+  - **Refuted**: `pollIntervalMillis`'s 30s floor removing the old "0 =
+    monitoring off" state (unreachable — Settings clamps 1–30 min, DB default
+    is 5 min, no write path produces 0); poll-interval-vs-alarm-rate-limit
+    ratio (by design per `docs/Spec.md`: 1–30 min poll range, fixed 5 min
+    rate limit, pre-existing whenever exact alarms were previously enabled);
+    `BootCompletedReceiver`'s removed synchronous notification (a net
+    improvement — it used to show "Monitoring active" unconditionally even
+    on total scheduling failure); the v8→v9 `dropColumn` "old SQLite"
+    concern (`sqlite3_flutter_libs` bundles its own recent SQLite, not the
+    OS/WebView one — DROP COLUMN has been supported since SQLite 3.35, 2021);
+    the iOS/non-Android no-op path (iOS is explicitly out of scope per
+    AGENTS.md).
+  - Re-ran `flutter analyze` (clean), `flutter test` (211/211), and
+    `dart format` (clean) after applying fixes.
 - ☐ Manual verification on the reporter's Pixel 9 (see the limitation note
   above) — could not be done in this sandboxed session.

--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -40,7 +40,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = 26
-        targetSdk = 34
+        targetSdk = 35
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
@@ -45,6 +45,19 @@
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
+
+        <!-- Warning: Do not change this service name; flutter_foreground_task -->
+        <!-- resolves it by this exact class. specialUse (not dataSync) avoids -->
+        <!-- Android 15's 6h/24h dataSync runtime cap and its restriction on -->
+        <!-- launching dataSync services from BOOT_COMPLETED. -->
+        <service
+            android:name="com.pravera.flutter_foreground_task.service.ForegroundService"
+            android:foregroundServiceType="specialUse"
+            android:exported="false">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Continuously polls configured thermostat sensors and raises an audible alarm when a reading leaves its safe operating range." />
+        </service>
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/app/android/app/src/main/kotlin/com/example/farmctl/BootCompletedReceiver.kt
+++ b/app/android/app/src/main/kotlin/com/example/farmctl/BootCompletedReceiver.kt
@@ -1,16 +1,17 @@
 package com.example.farmctl
 
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.os.Build
-import androidx.core.app.NotificationCompat
 import io.flutter.FlutterInjector
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.embedding.engine.dart.DartExecutor
 
+// flutter_foreground_task also auto-restarts the monitoring service on boot
+// (ForegroundTaskOptions.autoRunOnBoot) via its own native receiver, and posts
+// its own persistent notification once it does — this receiver is a second,
+// independent path that additionally re-registers the WorkManager watchdog.
+// A redundant start attempt from either path is a harmless no-op.
 class BootCompletedReceiver : BroadcastReceiver() {
   override fun onReceive(context: Context, intent: Intent?) {
     val action = intent?.action ?: return
@@ -19,38 +20,6 @@ class BootCompletedReceiver : BroadcastReceiver() {
       return
     }
 
-    val channelId = "farmctl_monitoring"
-    val channelName = "Thermostat monitoring"
-    val channelDescription =
-      "Shows when FarmCtl is checking thermostats in the background."
-
-    val manager =
-      context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      val channel = NotificationChannel(
-        channelId,
-        channelName,
-        NotificationManager.IMPORTANCE_LOW,
-      )
-      channel.description = channelDescription
-      manager.createNotificationChannel(channel)
-    }
-
-    val notification = NotificationCompat.Builder(context, channelId)
-      .setSmallIcon(context.applicationInfo.icon)
-      .setContentTitle("FarmCtl monitoring")
-      .setContentText("Monitoring active")
-      .setOngoing(true)
-      .setPriority(NotificationCompat.PRIORITY_LOW)
-      .setCategory(NotificationCompat.CATEGORY_SERVICE)
-      .setAutoCancel(false)
-      .build()
-
-    // Re-post the persistent monitoring notification after boot/update
-    manager.notify(1001, notification)
-
-    // Also restore WorkManager/Alarm schedule by invoking the Dart entrypoint.
     try {
       val loader = FlutterInjector.instance().flutterLoader()
       loader.startInitialization(context)
@@ -60,7 +29,8 @@ class BootCompletedReceiver : BroadcastReceiver() {
       val entrypoint = DartExecutor.DartEntrypoint(appBundlePath, "initializeMonitoringOnBoot")
       engine.dartExecutor.executeDartEntrypoint(entrypoint)
     } catch (_: Throwable) {
-      // Best-effort; WorkManager should still restore its periodic task.
+      // Best-effort; flutter_foreground_task's own autoRunOnBoot should still
+      // restore the service.
     }
   }
 }

--- a/app/lib/core/background/thermostat_monitor.dart
+++ b/app/lib/core/background/thermostat_monitor.dart
@@ -81,9 +81,13 @@ ForegroundTaskOptions _foregroundTaskOptions(Duration pollInterval) {
 /// run. Unlike the old WorkManager+AlarmManager pair, a live foreground
 /// service is exempt from Doze/App Standby deferral, so this is the single
 /// source of truth for polling cadence — no exact-alarm permission needed.
-Future<void> _ensureForegroundServiceRunning(Duration pollInterval) async {
+///
+/// Returns whether the service is confirmed running/updated, so a caller like
+/// the watchdog can propagate a failure instead of reporting success for a
+/// service that never actually started.
+Future<bool> _ensureForegroundServiceRunning(Duration pollInterval) async {
   if (!_supportsForegroundService) {
-    return;
+    return true;
   }
 
   try {
@@ -94,8 +98,9 @@ Future<void> _ensureForegroundServiceRunning(Duration pollInterval) async {
       );
       if (result is ServiceRequestFailure) {
         debugPrint('Failed to update monitoring service: ${result.error}');
+        return false;
       }
-      return;
+      return true;
     }
 
     // init() populates isolate-local static config that startService() reads
@@ -126,10 +131,13 @@ Future<void> _ensureForegroundServiceRunning(Duration pollInterval) async {
     );
     if (result is ServiceRequestFailure) {
       debugPrint('Failed to start monitoring service: ${result.error}');
+      return false;
     }
+    return true;
   } catch (error, stackTrace) {
     debugPrint('Failed to ensure monitoring service is running: $error');
     debugPrint('$stackTrace');
+    return false;
   }
 }
 
@@ -276,8 +284,9 @@ Future<bool> _runWatchdogTask() async {
       await database.close();
     }
 
-    await _ensureForegroundServiceRunning(config.pollInterval);
-    return true;
+    // Propagate a failed restart so WorkManager retries with backoff instead
+    // of waiting the full 15-minute watchdog period while monitoring is dead.
+    return await _ensureForegroundServiceRunning(config.pollInterval);
   } catch (error, stackTrace) {
     debugPrint('Watchdog failed to restart monitoring service: $error');
     debugPrint('$stackTrace');

--- a/app/lib/core/background/thermostat_monitor.dart
+++ b/app/lib/core/background/thermostat_monitor.dart
@@ -22,10 +22,10 @@ import '../../features/thermostats/models/thermostat_state.dart';
 import '../router/app_router.dart';
 import '../router/router_keys.dart';
 
-// WorkManager's task name/unique name are retained for the watchdog role (see
-// `_runWatchdogTask`): it no longer performs the monitor run itself.
-const String thermostatMonitorTask = 'thermostat_watchdog_task';
-const String thermostatMonitorUniqueName = 'thermostat_monitor_periodic';
+// WorkManager now only restarts the foreground service if it's dead — it
+// never performs the monitor run itself (see `_runWatchdogTask`).
+const String thermostatWatchdogTask = 'thermostat_watchdog_task';
+const String thermostatWatchdogUniqueName = 'thermostat_monitor_periodic';
 
 const String _monitoringChannelId = 'farmctl_monitoring';
 const String _monitoringChannelName = 'Thermostat monitoring';
@@ -46,11 +46,10 @@ const int _alarmNotificationBaseId = 4000;
 // interval, so it always uses the platform floor.
 const Duration _watchdogFrequency = Duration(minutes: 15);
 
-// Collapses the near-simultaneous onStart + onRepeatEvent (or watchdog restart)
-// fires into a single monitor run. Kept short so it stays below both the 60s+
-// gap between legitimate consecutive runs AND the WorkManager retry backoff —
-// otherwise a failed run's own retry could be debounced away (the run-start
-// stamp is written before the run and persists on failure).
+// Secondary safety net behind the in-isolate `_monitorRunInProgress` lock (see
+// below): collapses a near-simultaneous onStart + onRepeatEvent fire into a
+// single monitor run if they ever reach the DB check before the lock is set.
+// Kept well short of the 60s+ gap between legitimate consecutive runs.
 const Duration _monitorRunDebounce = Duration(seconds: 10);
 
 bool get _supportsForegroundService => !kIsWeb && Platform.isAndroid;
@@ -67,28 +66,14 @@ int pollIntervalMillis(
   return effective.inMilliseconds;
 }
 
-void _initForegroundTask(Duration pollInterval) {
-  FlutterForegroundTask.init(
-    androidNotificationOptions: AndroidNotificationOptions(
-      channelId: _monitoringChannelId,
-      channelName: _monitoringChannelName,
-      channelDescription: _monitoringChannelDescription,
-      channelImportance: NotificationChannelImportance.LOW,
-      priority: NotificationPriority.LOW,
-      onlyAlertOnce: true,
+ForegroundTaskOptions _foregroundTaskOptions(Duration pollInterval) {
+  return ForegroundTaskOptions(
+    eventAction: ForegroundTaskEventAction.repeat(
+      pollIntervalMillis(pollInterval),
     ),
-    iosNotificationOptions: const IOSNotificationOptions(
-      showNotification: false,
-      playSound: false,
-    ),
-    foregroundTaskOptions: ForegroundTaskOptions(
-      eventAction: ForegroundTaskEventAction.repeat(
-        pollIntervalMillis(pollInterval),
-      ),
-      autoRunOnBoot: true,
-      autoRunOnMyPackageReplaced: true,
-      allowWakeLock: true,
-    ),
+    autoRunOnBoot: true,
+    autoRunOnMyPackageReplaced: true,
+    allowWakeLock: true,
   );
 }
 
@@ -101,26 +86,36 @@ Future<void> _ensureForegroundServiceRunning(Duration pollInterval) async {
     return;
   }
 
-  _initForegroundTask(pollInterval);
-
   try {
     final running = await FlutterForegroundTask.isRunningService;
     if (running) {
       final result = await FlutterForegroundTask.updateService(
-        foregroundTaskOptions: ForegroundTaskOptions(
-          eventAction: ForegroundTaskEventAction.repeat(
-            pollIntervalMillis(pollInterval),
-          ),
-          autoRunOnBoot: true,
-          autoRunOnMyPackageReplaced: true,
-          allowWakeLock: true,
-        ),
+        foregroundTaskOptions: _foregroundTaskOptions(pollInterval),
       );
       if (result is ServiceRequestFailure) {
         debugPrint('Failed to update monitoring service: ${result.error}');
       }
       return;
     }
+
+    // init() populates isolate-local static config that startService() reads
+    // (updateService() doesn't need it — it's a self-contained call), so it
+    // only needs to run on this, the cold-start, path.
+    FlutterForegroundTask.init(
+      androidNotificationOptions: AndroidNotificationOptions(
+        channelId: _monitoringChannelId,
+        channelName: _monitoringChannelName,
+        channelDescription: _monitoringChannelDescription,
+        channelImportance: NotificationChannelImportance.LOW,
+        priority: NotificationPriority.LOW,
+        onlyAlertOnce: true,
+      ),
+      iosNotificationOptions: const IOSNotificationOptions(
+        showNotification: false,
+        playSound: false,
+      ),
+      foregroundTaskOptions: _foregroundTaskOptions(pollInterval),
+    );
 
     final result = await FlutterForegroundTask.startService(
       serviceId: _foregroundServiceId,
@@ -215,8 +210,8 @@ Future<void> initializeBackgroundMonitoring({Duration? pollFrequency}) async {
   // itself, so it can't double-poll alongside the live service.
   await Workmanager().initialize(thermostatMonitorCallbackDispatcher);
   await Workmanager().registerPeriodicTask(
-    thermostatMonitorUniqueName,
-    thermostatMonitorTask,
+    thermostatWatchdogUniqueName,
+    thermostatWatchdogTask,
     frequency: _watchdogFrequency,
     existingWorkPolicy: ExistingPeriodicWorkPolicy.update,
     constraints: Constraints(networkType: NetworkType.connected),
@@ -248,6 +243,17 @@ void thermostatMonitorCallbackDispatcher() {
 
 /// Restarts the foreground service if it isn't running. Does not fetch or
 /// write thermostat data itself — the live service already handles that.
+///
+/// Not redundant with the plugin's own `allowAutoRestart`/`autoRunOnBoot`:
+/// those recover from the OS killing the *service* (or a device reboot), but
+/// not from an OEM battery manager killing the whole app *process* outside
+/// of a device reboot — which is the actual Pixel 9 failure mode this file
+/// was reworked for. WorkManager's periodic work is OS-scheduled
+/// (JobScheduler-backed) independent of the app process being alive, so it
+/// still fires and can relaunch a fresh process. (A user-initiated "Force
+/// stop" is the one thing nothing here can survive — Android deliberately
+/// suspends all of an app's scheduled work, including WorkManager, until the
+/// user manually reopens it.)
 Future<bool> _runWatchdogTask() async {
   WidgetsFlutterBinding.ensureInitialized();
   ui.DartPluginRegistrant.ensureInitialized();

--- a/app/lib/core/background/thermostat_monitor.dart
+++ b/app/lib/core/background/thermostat_monitor.dart
@@ -1,10 +1,11 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:ui' as ui;
 
-import 'package:android_alarm_manager_plus/android_alarm_manager_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:go_router/go_router.dart';
 import 'package:workmanager/workmanager.dart';
@@ -21,17 +22,16 @@ import '../../features/thermostats/models/thermostat_state.dart';
 import '../router/app_router.dart';
 import '../router/router_keys.dart';
 
-const String thermostatMonitorTask = 'thermostat_monitor_task';
+// WorkManager's task name/unique name are retained for the watchdog role (see
+// `_runWatchdogTask`): it no longer performs the monitor run itself.
+const String thermostatMonitorTask = 'thermostat_watchdog_task';
 const String thermostatMonitorUniqueName = 'thermostat_monitor_periodic';
 
-const AndroidNotificationChannel _monitoringChannel =
-    AndroidNotificationChannel(
-      'farmctl_monitoring',
-      'Thermostat monitoring',
-      description:
-          'Shows when FarmCtl is checking thermostats in the background.',
-      importance: Importance.low,
-    );
+const String _monitoringChannelId = 'farmctl_monitoring';
+const String _monitoringChannelName = 'Thermostat monitoring';
+const String _monitoringChannelDescription =
+    'Shows when FarmCtl is checking thermostats in the background.';
+const int _foregroundServiceId = 256;
 
 const String _alarmChannelPrefix = 'farmctl_alarm';
 const String _alarmChannelName = 'Thermostat alarms';
@@ -39,142 +39,129 @@ const String _alarmChannelDescription =
     'Alerts when a thermostat leaves the configured range.';
 const String _defaultAlarmSoundUri = 'content://settings/system/alarm_alert';
 
-const int _monitoringNotificationId = 1001;
 const int _alarmNotificationBaseId = 4000;
-const Duration _minimumFrequency = Duration(minutes: 15);
-const int _alarmRequestId = 5001;
 
-// Collapses the near-simultaneous WorkManager + AlarmManager fires (which land
-// within a few seconds of each other) into a single monitor run. Kept short so
-// it stays below both the 60s+ gap between legitimate consecutive runs AND the
-// WorkManager retry backoff — otherwise a failed run's own retry could be
-// debounced away (the run-start stamp is written before the run and persists on
-// failure).
+// WorkManager can't run more often than every 15 minutes; the watchdog only
+// needs to notice a dead foreground service, not track the user's poll
+// interval, so it always uses the platform floor.
+const Duration _watchdogFrequency = Duration(minutes: 15);
+
+// Collapses the near-simultaneous onStart + onRepeatEvent (or watchdog restart)
+// fires into a single monitor run. Kept short so it stays below both the 60s+
+// gap between legitimate consecutive runs AND the WorkManager retry backoff —
+// otherwise a failed run's own retry could be debounced away (the run-start
+// stamp is written before the run and persists on failure).
 const Duration _monitorRunDebounce = Duration(seconds: 10);
 
-// Used to keep the one-shot alarm chain alive when the real config can't be
-// loaded (e.g. a transient DB/secure-storage failure), so polling doesn't
-// silently drop to the WorkManager floor.
-const AlertConfig _fallbackConfig = AlertConfig(
-  pollInterval: Duration(minutes: 5),
-  exactAlarmsEnabled: false,
-  soundUri: null,
-  vibrate: true,
-  volumeBoost: false,
-  pauseAllUntil: null,
-  githubToken: null,
-);
+bool get _supportsForegroundService => !kIsWeb && Platform.isAndroid;
 
-bool _alarmManagerInitialized = false;
+/// Converts [pollInterval] to milliseconds for the foreground service's
+/// `onRepeatEvent` cadence, clamped to a defensive floor so a corrupt/zero
+/// config value can't spin the repeat loop unreasonably fast. Pure for
+/// testability.
+int pollIntervalMillis(
+  Duration pollInterval, {
+  Duration minimum = const Duration(seconds: 30),
+}) {
+  final effective = pollInterval < minimum ? minimum : pollInterval;
+  return effective.inMilliseconds;
+}
 
-bool get _supportsAlarmScheduling => !kIsWeb && Platform.isAndroid;
+void _initForegroundTask(Duration pollInterval) {
+  FlutterForegroundTask.init(
+    androidNotificationOptions: AndroidNotificationOptions(
+      channelId: _monitoringChannelId,
+      channelName: _monitoringChannelName,
+      channelDescription: _monitoringChannelDescription,
+      channelImportance: NotificationChannelImportance.LOW,
+      priority: NotificationPriority.LOW,
+      onlyAlertOnce: true,
+    ),
+    iosNotificationOptions: const IOSNotificationOptions(
+      showNotification: false,
+      playSound: false,
+    ),
+    foregroundTaskOptions: ForegroundTaskOptions(
+      eventAction: ForegroundTaskEventAction.repeat(
+        pollIntervalMillis(pollInterval),
+      ),
+      autoRunOnBoot: true,
+      autoRunOnMyPackageReplaced: true,
+      allowWakeLock: true,
+    ),
+  );
+}
 
-Future<void> _ensureAlarmManagerInitialized() async {
-  if (!_supportsAlarmScheduling) {
+/// Starts (or reconfigures) the foreground service that drives every monitor
+/// run. Unlike the old WorkManager+AlarmManager pair, a live foreground
+/// service is exempt from Doze/App Standby deferral, so this is the single
+/// source of truth for polling cadence — no exact-alarm permission needed.
+Future<void> _ensureForegroundServiceRunning(Duration pollInterval) async {
+  if (!_supportsForegroundService) {
     return;
   }
-  if (_alarmManagerInitialized) {
-    return;
-  }
+
+  _initForegroundTask(pollInterval);
+
   try {
-    final initialized = await AndroidAlarmManager.initialize();
-    if (initialized) {
-      _alarmManagerInitialized = true;
-    } else {
-      debugPrint('AndroidAlarmManager.initialize returned false');
+    final running = await FlutterForegroundTask.isRunningService;
+    if (running) {
+      final result = await FlutterForegroundTask.updateService(
+        foregroundTaskOptions: ForegroundTaskOptions(
+          eventAction: ForegroundTaskEventAction.repeat(
+            pollIntervalMillis(pollInterval),
+          ),
+          autoRunOnBoot: true,
+          autoRunOnMyPackageReplaced: true,
+          allowWakeLock: true,
+        ),
+      );
+      if (result is ServiceRequestFailure) {
+        debugPrint('Failed to update monitoring service: ${result.error}');
+      }
+      return;
+    }
+
+    final result = await FlutterForegroundTask.startService(
+      serviceId: _foregroundServiceId,
+      serviceTypes: const [ForegroundServiceTypes.specialUse],
+      notificationTitle: 'FarmCtl monitoring',
+      notificationText: 'Monitoring active',
+      callback: thermostatForegroundTaskCallback,
+    );
+    if (result is ServiceRequestFailure) {
+      debugPrint('Failed to start monitoring service: ${result.error}');
     }
   } catch (error, stackTrace) {
-    debugPrint('Failed to initialize AndroidAlarmManager: $error');
+    debugPrint('Failed to ensure monitoring service is running: $error');
     debugPrint('$stackTrace');
   }
 }
 
-/// The next time (UTC) the monitor should run: `now + pollInterval`, deferred to
-/// the end of an active pause. Returns null when the interval is non-positive
-/// (monitoring effectively off). Pure so the polling cadence is unit-testable.
-DateTime? nextMonitorRunUtc(AlertConfig config, DateTime nowUtc) {
-  final interval = config.pollInterval;
-  if (interval <= Duration.zero) {
-    return null;
-  }
-
-  var target = nowUtc.add(interval);
-  final pauseUntil = config.pauseAllUntil;
-  if (pauseUntil != null && pauseUntil.isAfter(target)) {
-    target = pauseUntil;
-  }
-
-  return target;
+/// Entry point run in the foreground service's own isolate; must be a
+/// top-level function per the flutter_foreground_task contract.
+@pragma('vm:entry-point')
+void thermostatForegroundTaskCallback() {
+  WidgetsFlutterBinding.ensureInitialized();
+  ui.DartPluginRegistrant.ensureInitialized();
+  FlutterForegroundTask.setTaskHandler(_ThermostatMonitorTaskHandler());
 }
 
-/// The effective WorkManager periodic frequency: the configured interval clamped
-/// up to the 15-minute platform minimum. Pure for testability.
-Duration effectiveMonitorFrequency(Duration configuredInterval) {
-  return configuredInterval < _minimumFrequency
-      ? _minimumFrequency
-      : configuredInterval;
-}
-
-DateTime? _computeNextAlarmTime(AlertConfig config, DateTime nowUtc) {
-  return nextMonitorRunUtc(config, nowUtc)?.toLocal();
-}
-
-Future<void> _updateAlarmSchedule(AlertConfig config, {DateTime? now}) async {
-  if (!_supportsAlarmScheduling) {
-    return;
+class _ThermostatMonitorTaskHandler extends TaskHandler {
+  @override
+  Future<void> onStart(DateTime timestamp, TaskStarter starter) async {
+    // Check immediately on start (fresh install, reboot, or a watchdog
+    // restart) rather than waiting a full poll interval for the first read.
+    unawaited(_runMonitorTask());
   }
 
-  await _ensureAlarmManagerInitialized();
-  if (!_alarmManagerInitialized) {
-    return;
+  @override
+  void onRepeatEvent(DateTime timestamp) {
+    unawaited(_runMonitorTask());
   }
 
-  final nowUtc = (now ?? DateTime.now()).toUtc();
-  final nextRun = _computeNextAlarmTime(config, nowUtc);
-  if (nextRun == null) {
-    await AndroidAlarmManager.cancel(_alarmRequestId);
-    return;
-  }
-
-  final useExact = config.exactAlarmsEnabled;
-  var scheduled = await _scheduleMonitorOneShot(nextRun, exact: useExact);
-  if (!scheduled && useExact) {
-    // Exact scheduling throws if SCHEDULE_EXACT_ALARM was revoked since the user
-    // enabled it. Downgrade to a flexible alarm so checks keep happening rather
-    // than silently breaking the one-shot chain.
-    debugPrint(
-      'Exact alarm scheduling failed; falling back to a flexible alarm.',
-    );
-    scheduled = await _scheduleMonitorOneShot(nextRun, exact: false);
-  }
-  if (!scheduled) {
-    debugPrint('Unable to schedule the next monitor alarm.');
-  }
-}
-
-Future<bool> _scheduleMonitorOneShot(
-  DateTime nextRun, {
-  required bool exact,
-}) async {
-  try {
-    // oneShotAt returns false if scheduling was refused without throwing; honour
-    // it so the exact -> flexible downgrade still triggers in that case.
-    return await AndroidAlarmManager.oneShotAt(
-      nextRun,
-      _alarmRequestId,
-      thermostatAlarmCallback,
-      allowWhileIdle: true,
-      exact: exact,
-      wakeup: true,
-      rescheduleOnReboot: true,
-    );
-  } catch (error, stackTrace) {
-    debugPrint(
-      'Failed to schedule ${exact ? 'exact' : 'flexible'} alarm: $error',
-    );
-    debugPrint('$stackTrace');
-    return false;
-  }
+  @override
+  Future<void> onDestroy(DateTime timestamp, bool isTimeout) async {}
 }
 
 const String _snooze5ActionId = 'alarm_snooze_5';
@@ -219,27 +206,21 @@ Future<void> initializeBackgroundMonitoring({Duration? pollFrequency}) async {
 
   final configuredInterval =
       pollFrequency ?? config?.pollInterval ?? const Duration(minutes: 5);
-  final effectiveFrequency = effectiveMonitorFrequency(configuredInterval);
 
+  // The foreground service is the single source of truth for polling cadence.
+  await _ensureForegroundServiceRunning(configuredInterval);
+
+  // WorkManager is demoted to a watchdog: it only restarts the foreground
+  // service if the OS killed the whole app process, never runs the monitor
+  // itself, so it can't double-poll alongside the live service.
   await Workmanager().initialize(thermostatMonitorCallbackDispatcher);
   await Workmanager().registerPeriodicTask(
     thermostatMonitorUniqueName,
     thermostatMonitorTask,
-    frequency: effectiveFrequency,
+    frequency: _watchdogFrequency,
     existingWorkPolicy: ExistingPeriodicWorkPolicy.update,
     constraints: Constraints(networkType: NetworkType.connected),
   );
-
-  if (config != null) {
-    final schedulingConfig = pollFrequency != null
-        ? config.copyWith(pollInterval: pollFrequency)
-        : config;
-    await _updateAlarmSchedule(schedulingConfig);
-  }
-
-  // Keep a persistent low-priority notification visible between runs so the
-  // user knows monitoring is active.
-  await _showMonitoringActiveNotification(notifications);
 }
 
 // Entry point used by the Android BootCompletedReceiver to restore scheduling
@@ -261,13 +242,41 @@ void thermostatMonitorCallbackDispatcher() {
   Workmanager().executeTask((taskName, inputData) async {
     // Returning false on failure lets WorkManager retry with backoff instead of
     // waiting a full period after a transient error.
-    return _runMonitorTask();
+    return _runWatchdogTask();
   });
 }
 
-@pragma('vm:entry-point')
-Future<void> thermostatAlarmCallback() async {
-  await _runMonitorTask();
+/// Restarts the foreground service if it isn't running. Does not fetch or
+/// write thermostat data itself — the live service already handles that.
+Future<bool> _runWatchdogTask() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  ui.DartPluginRegistrant.ensureInitialized();
+
+  if (!_supportsForegroundService) {
+    return true;
+  }
+
+  try {
+    if (await FlutterForegroundTask.isRunningService) {
+      return true;
+    }
+
+    debugPrint('Watchdog: monitoring service is not running; restarting.');
+    final database = ThermostatDatabase();
+    AlertConfig? config;
+    try {
+      config = await AlertConfigRepository(database).loadConfig();
+    } finally {
+      await database.close();
+    }
+
+    await _ensureForegroundServiceRunning(config.pollInterval);
+    return true;
+  } catch (error, stackTrace) {
+    debugPrint('Watchdog failed to restart monitoring service: $error');
+    debugPrint('$stackTrace');
+    return false;
+  }
 }
 
 /// Whether a monitor run that observed [lastRunStartedAt] should be skipped
@@ -304,24 +313,18 @@ Future<bool> _runMonitorTask() async {
   if (config == null) {
     debugPrint('Alert config unavailable; skipping monitor run.');
     await database.close();
-    // Keep the one-shot alarm chain alive at a safe default cadence so polling
-    // doesn't silently drop to the WorkManager floor while the config is
-    // transiently unreadable.
-    await _updateAlarmSchedule(_fallbackConfig);
-    // Treat a failed config load as a failure so WorkManager retries.
     return false;
   }
 
   final now = DateTime.now().toUtc();
 
-  // Debounce the overlapping WorkManager + AlarmManager triggers into a single
+  // Debounce the overlapping onStart + onRepeatEvent triggers into a single
   // run rather than fetching and writing the same rows twice.
   if (shouldSkipMonitorRun(
     lastRunStartedAt: config.lastMonitorRunAt,
     now: now,
   )) {
     debugPrint('Skipping monitor run; another run started recently.');
-    await _updateAlarmSchedule(config, now: now);
     await database.close();
     return true;
   }
@@ -334,12 +337,6 @@ Future<bool> _runMonitorTask() async {
     debugPrint('$stackTrace');
   }
 
-  // Show a transient notification while the check is running.
-  await _showMonitoringNotification(notifications);
-
-  // Reschedule from the freshest config so a pollInterval / pause change made
-  // during this (possibly multi-second) run is honored by the next wakeup.
-  var scheduleConfig = config;
   var success = true;
   try {
     final alertConfig = config; // promote to non-null for closures
@@ -371,23 +368,14 @@ Future<bool> _runMonitorTask() async {
       debugPrint('Retention pruning failed in background: $error');
       debugPrint('$stackTrace');
     }
-
-    try {
-      scheduleConfig = AlertConfig.fromEntry(await database.getAlertConfig());
-    } catch (_) {
-      // Keep the run-start config if the re-read fails.
-    }
   } catch (error, stackTrace) {
     success = false;
     debugPrint('Thermostat monitor failed: $error');
     debugPrint('$stackTrace');
   } finally {
-    // Switch back to the persistent monitoring indicator when the run ends.
-    await _showMonitoringActiveNotification(notifications);
     await database.close();
   }
 
-  await _updateAlarmSchedule(scheduleConfig, now: now);
   return success;
 }
 
@@ -716,7 +704,9 @@ Future<void> _initializeNotifications(
       .resolvePlatformSpecificImplementation<
         AndroidFlutterLocalNotificationsPlugin
       >();
-  await androidPlugin?.createNotificationChannel(_monitoringChannel);
+  // The persistent "monitoring active" notification/channel is owned by the
+  // foreground service (flutter_foreground_task) now; only the alarm channels
+  // are created here.
   final soundUris = <String?>{null};
   final customSound = config?.soundUri;
   if (customSound != null && customSound.isNotEmpty) {
@@ -728,62 +718,13 @@ Future<void> _initializeNotifications(
   }
 }
 
-Future<void> _showMonitoringNotification(
-  FlutterLocalNotificationsPlugin plugin,
-) {
-  return plugin.show(
-    _monitoringNotificationId,
-    'FarmCtl monitoring',
-    'Checking thermostats…',
-    NotificationDetails(
-      android: AndroidNotificationDetails(
-        _monitoringChannel.id,
-        _monitoringChannel.name,
-        channelDescription: _monitoringChannel.description,
-        importance: Importance.low,
-        priority: Priority.low,
-        ongoing: true,
-        showWhen: false,
-        playSound: false,
-        enableVibration: false,
-      ),
-    ),
-  );
-}
-
-Future<void> _showMonitoringActiveNotification(
-  FlutterLocalNotificationsPlugin plugin,
-) {
-  return plugin.show(
-    _monitoringNotificationId,
-    'FarmCtl monitoring',
-    'Monitoring active',
-    NotificationDetails(
-      android: AndroidNotificationDetails(
-        _monitoringChannel.id,
-        _monitoringChannel.name,
-        channelDescription: _monitoringChannel.description,
-        importance: Importance.low,
-        priority: Priority.low,
-        // Make this notification non-dismissible by swipe
-        autoCancel: false,
-        ongoing: true,
-        category: AndroidNotificationCategory.service,
-        showWhen: false,
-        playSound: false,
-        enableVibration: false,
-      ),
-    ),
-  );
-}
-
 /// Routes a cold-launch alarm-notification tap to the alarm screen.
 ///
 /// `onDidReceiveNotificationResponse` only fires while the Dart isolate is
 /// alive, so a tap that *launches* the app from a terminated state is delivered
 /// only via the launch details. Call this once during app startup.
 Future<void> handleNotificationLaunch() async {
-  if (!_supportsAlarmScheduling) {
+  if (!_supportsForegroundService) {
     return;
   }
   try {

--- a/app/lib/core/background/thermostat_monitor.dart
+++ b/app/lib/core/background/thermostat_monitor.dart
@@ -293,7 +293,29 @@ bool shouldSkipMonitorRun({
   return elapsed >= Duration.zero && elapsed < debounce;
 }
 
+// Guards against onStart and onRepeatEvent (the only two callers, both in the
+// foreground service's own isolate) interleaving at an `await` inside a run:
+// the DB-backed shouldSkipMonitorRun check is check-then-write across two
+// separate awaits, so two calls that both reach it before either has written
+// lastMonitorRunAt would both proceed. This flag's check-and-set is
+// synchronous (no await in between), so within a single isolate it can't race
+// the same way.
+bool _monitorRunInProgress = false;
+
 Future<bool> _runMonitorTask() async {
+  if (_monitorRunInProgress) {
+    debugPrint('Skipping monitor run; one is already in progress.');
+    return true;
+  }
+  _monitorRunInProgress = true;
+  try {
+    return await _runMonitorTaskLocked();
+  } finally {
+    _monitorRunInProgress = false;
+  }
+}
+
+Future<bool> _runMonitorTaskLocked() async {
   WidgetsFlutterBinding.ensureInitialized();
   ui.DartPluginRegistrant.ensureInitialized();
 

--- a/app/lib/features/settings/data/alert_config_repository.dart
+++ b/app/lib/features/settings/data/alert_config_repository.dart
@@ -102,12 +102,6 @@ class AlertConfigRepository {
     );
   }
 
-  Future<void> setExactAlarmsEnabled(bool enabled) async {
-    await _database.updateAlertConfig(
-      AlertConfigEntriesCompanion(exactAlarmsEnabled: Value(enabled)),
-    );
-  }
-
   Future<void> setSoundUri(String? uri) async {
     await _database.updateAlertConfig(
       AlertConfigEntriesCompanion(soundUri: Value(uri)),

--- a/app/lib/features/settings/models/alert_config.dart
+++ b/app/lib/features/settings/models/alert_config.dart
@@ -6,7 +6,6 @@ import '../../thermostats/data/thermostat_database.dart';
 class AlertConfig {
   const AlertConfig({
     required this.pollInterval,
-    required this.exactAlarmsEnabled,
     required this.soundUri,
     required this.vibrate,
     required this.volumeBoost,
@@ -16,7 +15,6 @@ class AlertConfig {
   });
 
   final Duration pollInterval;
-  final bool exactAlarmsEnabled;
   final String? soundUri;
   final bool vibrate;
   final bool volumeBoost;
@@ -24,13 +22,13 @@ class AlertConfig {
   final String? githubToken;
 
   /// When the background monitor last started a run. Used to debounce the
-  /// overlapping WorkManager + AlarmManager triggers into a single run.
+  /// overlapping foreground-service + WorkManager-watchdog triggers into a
+  /// single run.
   final DateTime? lastMonitorRunAt;
 
   factory AlertConfig.fromEntry(AlertConfigEntry entry) {
     return AlertConfig(
       pollInterval: Duration(minutes: entry.pollIntervalMin),
-      exactAlarmsEnabled: entry.exactAlarmsEnabled,
       soundUri: entry.soundUri,
       vibrate: entry.vibrate,
       volumeBoost: entry.volumeBoost,
@@ -46,7 +44,6 @@ class AlertConfig {
   AlertConfig withToken(String? token) {
     return AlertConfig(
       pollInterval: pollInterval,
-      exactAlarmsEnabled: exactAlarmsEnabled,
       soundUri: soundUri,
       vibrate: vibrate,
       volumeBoost: volumeBoost,
@@ -73,7 +70,6 @@ class AlertConfig {
 
   AlertConfig copyWith({
     Duration? pollInterval,
-    bool? exactAlarmsEnabled,
     String? soundUri,
     bool? vibrate,
     bool? volumeBoost,
@@ -83,7 +79,6 @@ class AlertConfig {
   }) {
     return AlertConfig(
       pollInterval: pollInterval ?? this.pollInterval,
-      exactAlarmsEnabled: exactAlarmsEnabled ?? this.exactAlarmsEnabled,
       soundUri: soundUri ?? this.soundUri,
       vibrate: vibrate ?? this.vibrate,
       volumeBoost: volumeBoost ?? this.volumeBoost,
@@ -98,7 +93,6 @@ class AlertConfig {
       identical(this, other) ||
       other is AlertConfig &&
           other.pollInterval == pollInterval &&
-          other.exactAlarmsEnabled == exactAlarmsEnabled &&
           other.soundUri == soundUri &&
           other.vibrate == vibrate &&
           other.volumeBoost == volumeBoost &&
@@ -109,7 +103,6 @@ class AlertConfig {
   @override
   int get hashCode => Object.hash(
     pollInterval,
-    exactAlarmsEnabled,
     soundUri,
     vibrate,
     volumeBoost,

--- a/app/lib/features/settings/services/developer_log_exporter.dart
+++ b/app/lib/features/settings/services/developer_log_exporter.dart
@@ -52,7 +52,6 @@ class DeveloperLogExporter {
   Map<String, dynamic> _serializeConfig(AlertConfig config) {
     return {
       'pollIntervalMinutes': config.pollInterval.inMinutes,
-      'exactAlarmsEnabled': config.exactAlarmsEnabled,
       'soundUri': config.soundUri,
       'vibrate': config.vibrate,
       'volumeBoost': config.volumeBoost,

--- a/app/lib/features/settings/view/settings_page.dart
+++ b/app/lib/features/settings/view/settings_page.dart
@@ -22,7 +22,6 @@ class SettingsPage extends ConsumerStatefulWidget {
 }
 
 class _SettingsPageState extends ConsumerState<SettingsPage> {
-  static const int _workManagerFloorMinutes = 15;
   double? _pollIntervalOverride;
 
   @override
@@ -38,9 +37,6 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
             onPollIntervalChanged: _handlePollIntervalChanged,
             onPollIntervalChangeEnd: (value) {
               _commitPollInterval(value);
-            },
-            onExactAlarmsChanged: (value) {
-              _setExactAlarmsEnabled(value);
             },
             onRequestBatteryExemption: _requestIgnoreBatteryOptimizations,
             onVibrateChanged: (value) {
@@ -91,18 +87,10 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
         pollFrequency: Duration(minutes: minutes),
       );
       if (!mounted) return;
-      final config = ref.read(alertConfigProvider).asData?.value;
-      final delayed =
-          config != null &&
-          !config.exactAlarmsEnabled &&
-          minutes < _workManagerFloorMinutes;
-      final suffix = delayed
-          ? ' (about every 15 min without exact alarms)'
-          : '';
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            'Checking every $minutes minute${minutes == 1 ? '' : 's'}$suffix',
+            'Checking every $minutes minute${minutes == 1 ? '' : 's'}',
           ),
         ),
       );
@@ -120,47 +108,9 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
     }
   }
 
-  Future<void> _setExactAlarmsEnabled(bool value) async {
-    final repository = ref.read(alertConfigRepositoryProvider);
-    try {
-      if (value) {
-        final granted = await _ensureExactAlarmPermission();
-        if (!granted) {
-          if (!mounted) return;
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text(
-                'Exact alarm permission is required to enable precise scheduling.',
-              ),
-            ),
-          );
-          return;
-        }
-      }
-
-      await repository.setExactAlarmsEnabled(value);
-      await initializeBackgroundMonitoring();
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            value
-                ? 'Exact alarms enabled. Monitoring will use precise scheduling.'
-                : 'Exact alarms disabled. Monitoring falls back to flexible scheduling.',
-          ),
-        ),
-      );
-    } catch (error) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(humanizeError(error))));
-    }
-  }
-
-  /// Requests the OS exemption from battery optimisation (Doze / app standby),
-  /// which is what lets the WorkManager + AlarmManager checks keep firing while
-  /// the app is in the background instead of being deferred for hours.
+  /// Requests the OS exemption from battery optimisation (Doze / app standby).
+  /// The foreground service is itself exempt from deferral while running, but
+  /// this still helps the OS start/keep it alive promptly (e.g. after boot).
   Future<void> _requestIgnoreBatteryOptimizations() async {
     if (kIsWeb || !Platform.isAndroid) {
       return;
@@ -210,83 +160,6 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
       if (!mounted) return;
       messenger.showSnackBar(SnackBar(content: Text(humanizeError(error))));
     }
-  }
-
-  Future<bool> _ensureExactAlarmPermission() async {
-    if (kIsWeb || !Platform.isAndroid) {
-      return true;
-    }
-
-    var status = await Permission.scheduleExactAlarm.status;
-    if (status.isGranted) {
-      return true;
-    }
-
-    if (!mounted) {
-      return false;
-    }
-
-    final shouldRequest =
-        await showDialog<bool>(
-          context: context,
-          builder: (context) => AlertDialog(
-            title: const Text('Allow exact alarms'),
-            content: const Text(
-              'FarmCtl needs the exact alarm permission to wake reliably when the device is idle.',
-            ),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(false),
-                child: const Text('Not now'),
-              ),
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(true),
-                child: const Text('Continue'),
-              ),
-            ],
-          ),
-        ) ??
-        false;
-
-    if (!shouldRequest) {
-      return false;
-    }
-
-    status = await Permission.scheduleExactAlarm.request();
-    if (status.isGranted) {
-      return true;
-    }
-
-    if (!mounted) {
-      return false;
-    }
-
-    await showDialog<void>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Enable exact alarms'),
-        content: const Text(
-          'Open system settings and enable "Allow exact alarms" for FarmCtl to improve scheduling reliability.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text('Close'),
-          ),
-          if (status.isPermanentlyDenied || status.isRestricted)
-            TextButton(
-              onPressed: () async {
-                final navigator = Navigator.of(context);
-                await openAppSettings();
-                navigator.pop();
-              },
-              child: const Text('Open settings'),
-            ),
-        ],
-      ),
-    );
-
-    return false;
   }
 
   Future<void> _setVibrateEnabled(bool value) async {
@@ -539,7 +412,6 @@ class _SettingsContent extends StatefulWidget {
     required this.pollIntervalOverride,
     required this.onPollIntervalChanged,
     required this.onPollIntervalChangeEnd,
-    required this.onExactAlarmsChanged,
     required this.onRequestBatteryExemption,
     required this.onVibrateChanged,
     required this.onVolumeBoostChanged,
@@ -557,7 +429,6 @@ class _SettingsContent extends StatefulWidget {
   final double? pollIntervalOverride;
   final ValueChanged<double> onPollIntervalChanged;
   final ValueChanged<double> onPollIntervalChangeEnd;
-  final ValueChanged<bool> onExactAlarmsChanged;
   final Future<void> Function() onRequestBatteryExemption;
   final ValueChanged<bool> onVibrateChanged;
   final ValueChanged<bool> onVolumeBoostChanged;
@@ -655,49 +526,6 @@ class _SettingsContentState extends State<_SettingsContent> {
                   Text(
                     '${sliderValue.round()} minute${sliderValue.round() == 1 ? '' : 's'}',
                     style: theme.textTheme.bodySmall,
-                  ),
-                  if (sliderValue.round() < 15 &&
-                      !widget.config.exactAlarmsEnabled) ...[
-                    const SizedBox(height: 6),
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Icon(
-                          Icons.info_outline,
-                          size: 16,
-                          color: theme.colorScheme.tertiary,
-                        ),
-                        const SizedBox(width: 6),
-                        Expanded(
-                          child: Text(
-                            'Without exact alarms, checks actually run about '
-                            'every 15 minutes.',
-                            style: theme.textTheme.bodySmall?.copyWith(
-                              color: theme.colorScheme.tertiary,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                  const SizedBox(height: 20),
-                  const Divider(),
-                  const SizedBox(height: 20),
-                  const _SettingsTileHeader(
-                    title: 'Exact alarms',
-                    subtitle:
-                        'Improve reliability on Android 12+ by requesting the exact alarm permission.',
-                  ),
-                  const SizedBox(height: 12),
-                  SwitchListTile.adaptive(
-                    value: widget.config.exactAlarmsEnabled,
-                    onChanged: widget.onExactAlarmsChanged,
-                    title: const Text('Allow exact alarms'),
-                    subtitle: const Text(
-                      'Lets FarmCtl ask for permission to schedule precise alarms.',
-                    ),
-                    contentPadding: EdgeInsets.zero,
-                    secondary: const Icon(Icons.alarm_on),
                   ),
                   if (!kIsWeb && Platform.isAndroid) ...[
                     const SizedBox(height: 20),

--- a/app/lib/features/thermostats/data/thermostat_database.dart
+++ b/app/lib/features/thermostats/data/thermostat_database.dart
@@ -69,9 +69,6 @@ class AlertConfigEntries extends Table {
 
   IntColumn get pollIntervalMin => integer().withDefault(const Constant(5))();
 
-  BoolColumn get exactAlarmsEnabled =>
-      boolean().withDefault(const Constant(false))();
-
   TextColumn get soundUri => text().nullable()();
 
   BoolColumn get vibrate => boolean().withDefault(const Constant(true))();
@@ -149,7 +146,7 @@ class ThermostatDatabase extends _$ThermostatDatabase {
   ThermostatDatabase.forTesting(super.executor);
 
   @override
-  int get schemaVersion => 8;
+  int get schemaVersion => 9;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -217,6 +214,12 @@ class ThermostatDatabase extends _$ThermostatDatabase {
           WHERE id <> (SELECT MIN(id) FROM alert_config_entries)
         ''');
         await customStatement('UPDATE alert_config_entries SET id = 1');
+      }
+      if (from < 9) {
+        // The AlarmManager exact-alarm scheduling path was removed in favour
+        // of a foreground service, which polls reliably without needing this
+        // permission; the column it configured is now unused.
+        await m.dropColumn(alertConfigEntries, 'exact_alarms_enabled');
       }
     },
   );
@@ -430,7 +433,8 @@ class ThermostatDatabase extends _$ThermostatDatabase {
   }
 
   /// Records when the background monitor last started a run so overlapping
-  /// triggers (WorkManager + AlarmManager) can be debounced into a single run.
+  /// triggers (the foreground service and the WorkManager watchdog) can be
+  /// debounced into a single run.
   Future<void> setLastMonitorRunAt(DateTime value) async {
     await updateAlertConfig(
       AlertConfigEntriesCompanion(lastMonitorRunAt: Value(value)),
@@ -472,7 +476,6 @@ class ThermostatDatabase extends _$ThermostatDatabase {
     return AlertConfigEntry(
       id: 1,
       pollIntervalMin: 5,
-      exactAlarmsEnabled: false,
       soundUri: null,
       vibrate: true,
       volumeBoost: false,

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -17,14 +17,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.0.1"
-  android_alarm_manager_plus:
-    dependency: "direct main"
-    description:
-      name: android_alarm_manager_plus
-      sha256: "752c948c1340609cd857d7d358f3be1ab2216e4937b8e4ddcd770cb2d95a2191"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.1.0"
   args:
     dependency: transitive
     description:
@@ -309,6 +301,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_foreground_task:
+    dependency: "direct main"
+    description:
+      name: flutter_foreground_task
+      sha256: fc5c01a5e1b8f7bb51d0c737714f0c50440dbdf1aeddc5f8cbba313aa6fd4856
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.2.2"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -632,10 +632,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -876,6 +876,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  shared_preferences:
+    dependency: transitive
+    description:
+      name: shared_preferences
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.5"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "93ae5884a9df5d3bb696825bceb3a17590754548b5d740eba51500afc8d088f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.26"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:
@@ -1029,26 +1085,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   timezone:
     dependency: transitive
     description:
@@ -1210,5 +1266,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.38.4"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   path_provider: ^2.1.5
   path: ^1.9.0
   workmanager: ^0.9.0+3
-  android_alarm_manager_plus: ^5.0.0
+  flutter_foreground_task: ^9.2.2
   flutter_local_notifications: ^19.4.2
   audio_session: ^0.2.2
   just_audio: ^0.10.5

--- a/app/test/unit/alert_config_repository_test.dart
+++ b/app/test/unit/alert_config_repository_test.dart
@@ -49,7 +49,6 @@ void main() {
     final config = await repository.loadConfig();
 
     expect(config.pollInterval, const Duration(minutes: 5));
-    expect(config.exactAlarmsEnabled, isFalse);
     expect(config.soundUri, isNull);
     expect(config.vibrate, isTrue);
     expect(config.volumeBoost, isFalse);
@@ -138,7 +137,7 @@ void main() {
       const AlertConfigEntriesCompanion(pollIntervalMin: Value(9)),
     );
     await database.updateAlertConfig(
-      const AlertConfigEntriesCompanion(exactAlarmsEnabled: Value(true)),
+      const AlertConfigEntriesCompanion(vibrate: Value(false)),
     );
     await database.setLastMonitorRunAt(DateTime.utc(2025, 6, 27, 12));
 
@@ -146,7 +145,7 @@ void main() {
     expect(rows, hasLength(1));
     final cfg = await database.getAlertConfig();
     expect(cfg.pollIntervalMin, 9);
-    expect(cfg.exactAlarmsEnabled, isTrue);
+    expect(cfg.vibrate, isFalse);
     expect(cfg.lastMonitorRunAt, isNotNull);
   });
 

--- a/app/test/unit/monitor_dependencies_test.dart
+++ b/app/test/unit/monitor_dependencies_test.dart
@@ -13,7 +13,6 @@ void main() {
 
     const config = AlertConfig(
       pollInterval: Duration(minutes: 5),
-      exactAlarmsEnabled: false,
       soundUri: null,
       vibrate: true,
       volumeBoost: false,

--- a/app/test/unit/thermostat_database_migration_test.dart
+++ b/app/test/unit/thermostat_database_migration_test.dart
@@ -67,9 +67,15 @@ void main() {
         ),
       ]);
 
-      // Simulate a v6 on-disk schema: drop the v7 column and rewind the version.
+      // Simulate a v6 on-disk schema: drop the v7 column, add back the
+      // exact_alarms_enabled column a real v6 table still had (dropped in
+      // v9), and rewind the version.
       await db.customStatement(
         'ALTER TABLE alert_config_entries DROP COLUMN last_monitor_run_at',
+      );
+      await db.customStatement(
+        'ALTER TABLE alert_config_entries '
+        'ADD COLUMN exact_alarms_enabled INTEGER NOT NULL DEFAULT 0',
       );
       await db.customStatement('PRAGMA user_version = 6');
       await db.close();
@@ -110,10 +116,16 @@ void main() {
     await db.customStatement(
       'ALTER TABLE alert_config_entries DROP COLUMN github_token',
     );
+    // A real v1 table had exact_alarms_enabled from the start (dropped in
+    // v9); add it back so this simulation matches actual v1 data.
+    await db.customStatement(
+      'ALTER TABLE alert_config_entries '
+      'ADD COLUMN exact_alarms_enabled INTEGER NOT NULL DEFAULT 0',
+    );
     await db.customStatement('PRAGMA user_version = 1');
     await db.close();
 
-    // Re-open: onUpgrade(1 -> 7) must run every step. Before the createTable/
+    // Re-open: onUpgrade(1 -> 9) must run every step. Before the createTable/
     // addColumn ordering fix this threw a duplicate-column error on v3.
     final upgraded = openDb();
 
@@ -142,6 +154,12 @@ void main() {
 
   test('upgrades v7 -> v8, consolidating duplicate alert_config rows', () async {
     final db = openDb();
+    // A real v7 on-disk table still had exact_alarms_enabled (dropped in v9);
+    // add it back so this raw-SQL simulation matches actual v7 data.
+    await db.customStatement(
+      'ALTER TABLE alert_config_entries '
+      'ADD COLUMN exact_alarms_enabled INTEGER NOT NULL DEFAULT 0',
+    );
     // Simulate the pre-fix duplicate-row state. id=1 is the LIVE row the app
     // reads/writes (poll=5, exact alarms off, token already migrated to secure
     // storage so the plaintext column is null); id=2 is a frozen leftover that
@@ -167,11 +185,38 @@ void main() {
     final rows = await upgraded.select(upgraded.alertConfigEntries).get();
     expect(rows, hasLength(1));
     final config = await upgraded.getAlertConfig();
-    // Live settings survive (NOT the stale id=2 values 9 / true)...
+    // Live settings survive (NOT the stale id=2 value 9)...
     expect(config.pollIntervalMin, 5);
-    expect(config.exactAlarmsEnabled, isFalse);
     // ...and the only token (from the duplicate) is forward-filled.
     expect(config.githubToken, 'ghp_seed');
     await upgraded.close();
   });
+
+  test(
+    'upgrades v8 -> v9, dropping the unused exact_alarms_enabled column',
+    () async {
+      final db = openDb();
+      await seedThermostat(db, 't1');
+      await db.updateAlertConfig(
+        const AlertConfigEntriesCompanion(pollIntervalMin: Value(7)),
+      );
+
+      // Simulate a v8 on-disk schema: add back the column the current (v9)
+      // schema no longer declares, then rewind the version.
+      await db.customStatement(
+        'ALTER TABLE alert_config_entries '
+        'ADD COLUMN exact_alarms_enabled INTEGER NOT NULL DEFAULT 0',
+      );
+      await db.customStatement('PRAGMA user_version = 8');
+      await db.close();
+
+      // Re-open: the real onUpgrade(8 -> 9) should run and the DB must still
+      // be usable (the dropped column is never read again).
+      final upgraded = openDb();
+      final config = await upgraded.getAlertConfig();
+      expect(config.pollIntervalMin, 7, reason: 'data must survive upgrade');
+      expect(await upgraded.listThermostats(), hasLength(1));
+      await upgraded.close();
+    },
+  );
 }

--- a/app/test/unit/thermostat_models_test.dart
+++ b/app/test/unit/thermostat_models_test.dart
@@ -110,7 +110,6 @@ void main() {
   group('AlertConfig', () {
     const base = AlertConfig(
       pollInterval: Duration(minutes: 5),
-      exactAlarmsEnabled: false,
       soundUri: null,
       vibrate: true,
       volumeBoost: false,

--- a/app/test/unit/thermostat_monitor_schedule_test.dart
+++ b/app/test/unit/thermostat_monitor_schedule_test.dart
@@ -1,22 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:farmctl/core/background/thermostat_monitor.dart';
-import 'package:farmctl/features/settings/models/alert_config.dart';
-
-AlertConfig _config({
-  Duration interval = const Duration(minutes: 5),
-  DateTime? pauseUntil,
-}) {
-  return AlertConfig(
-    pollInterval: interval,
-    exactAlarmsEnabled: false,
-    soundUri: null,
-    vibrate: true,
-    volumeBoost: false,
-    pauseAllUntil: pauseUntil,
-    githubToken: null,
-  );
-}
 
 void main() {
   group('shouldSkipMonitorRun', () {
@@ -92,77 +76,36 @@ void main() {
     });
   });
 
-  group('nextMonitorRunUtc', () {
-    final now = DateTime.utc(2025, 1, 1, 12);
-
-    test('schedules the next run exactly one poll interval ahead', () {
+  group('pollIntervalMillis', () {
+    test('converts a normal poll interval to milliseconds', () {
       expect(
-        nextMonitorRunUtc(_config(interval: const Duration(minutes: 1)), now),
-        now.add(const Duration(minutes: 1)),
+        pollIntervalMillis(const Duration(minutes: 1)),
+        const Duration(minutes: 1).inMilliseconds,
       );
       expect(
-        nextMonitorRunUtc(_config(interval: const Duration(minutes: 5)), now),
-        now.add(const Duration(minutes: 5)),
-      );
-      expect(
-        nextMonitorRunUtc(_config(interval: const Duration(minutes: 30)), now),
-        now.add(const Duration(minutes: 30)),
+        pollIntervalMillis(const Duration(minutes: 30)),
+        const Duration(minutes: 30).inMilliseconds,
       );
     });
 
-    test('returns null for a non-positive interval (monitoring off)', () {
-      expect(nextMonitorRunUtc(_config(interval: Duration.zero), now), isNull);
+    test('clamps below the defensive floor up to the floor', () {
+      expect(
+        pollIntervalMillis(Duration.zero),
+        const Duration(seconds: 30).inMilliseconds,
+      );
+      expect(
+        pollIntervalMillis(const Duration(seconds: 5)),
+        const Duration(seconds: 30).inMilliseconds,
+      );
     });
 
-    test('defers the next run to the end of an active pause', () {
-      final pauseUntil = now.add(const Duration(hours: 1));
+    test('honours a custom floor', () {
       expect(
-        nextMonitorRunUtc(
-          _config(interval: const Duration(minutes: 5), pauseUntil: pauseUntil),
-          now,
+        pollIntervalMillis(
+          const Duration(seconds: 5),
+          minimum: const Duration(seconds: 10),
         ),
-        pauseUntil,
-      );
-    });
-
-    test('ignores a pause that ends before the next interval', () {
-      final pauseUntil = now.add(const Duration(minutes: 2));
-      expect(
-        nextMonitorRunUtc(
-          _config(interval: const Duration(minutes: 5), pauseUntil: pauseUntil),
-          now,
-        ),
-        now.add(const Duration(minutes: 5)),
-      );
-    });
-  });
-
-  group('effectiveMonitorFrequency', () {
-    test('clamps sub-15-minute intervals up to the platform floor', () {
-      // WorkManager cannot run more often than every 15 minutes; the precise
-      // sub-15-minute cadence is driven by the AlarmManager one-shot instead.
-      expect(
-        effectiveMonitorFrequency(const Duration(minutes: 1)),
-        const Duration(minutes: 15),
-      );
-      expect(
-        effectiveMonitorFrequency(const Duration(minutes: 5)),
-        const Duration(minutes: 15),
-      );
-      expect(
-        effectiveMonitorFrequency(const Duration(minutes: 15)),
-        const Duration(minutes: 15),
-      );
-    });
-
-    test('honours intervals at or above the floor', () {
-      expect(
-        effectiveMonitorFrequency(const Duration(minutes: 20)),
-        const Duration(minutes: 20),
-      );
-      expect(
-        effectiveMonitorFrequency(const Duration(minutes: 30)),
-        const Duration(minutes: 30),
+        const Duration(seconds: 10).inMilliseconds,
       );
     });
   });

--- a/app/test/widget/settings_page_test.dart
+++ b/app/test/widget/settings_page_test.dart
@@ -8,14 +8,12 @@ import 'package:farmctl/features/settings/view/settings_page.dart';
 
 AlertConfig _config({
   Duration interval = const Duration(minutes: 5),
-  bool exact = false,
   String? sound,
   DateTime? pauseUntil,
   String? token,
 }) {
   return AlertConfig(
     pollInterval: interval,
-    exactAlarmsEnabled: exact,
     soundUri: sound,
     vibrate: true,
     volumeBoost: false,
@@ -48,7 +46,6 @@ void main() {
 
     expect(find.text('Settings'), findsOneWidget);
     expect(find.text('Poll interval'), findsOneWidget);
-    expect(find.text('Allow exact alarms'), findsOneWidget);
     expect(find.text('Pause monitoring'), findsOneWidget);
     expect(find.text('Resume monitoring'), findsOneWidget);
     expect(find.text('Alarm sound'), findsOneWidget);
@@ -67,22 +64,10 @@ void main() {
     expect(resume.onPressed, isNull);
   });
 
-  testWidgets('reflects the poll interval and an enabled exact-alarm switch', (
-    tester,
-  ) async {
-    await _pumpData(
-      tester,
-      _config(interval: const Duration(minutes: 12), exact: true),
-    );
+  testWidgets('reflects the configured poll interval', (tester) async {
+    await _pumpData(tester, _config(interval: const Duration(minutes: 12)));
 
     expect(find.text('12 minutes'), findsOneWidget);
-    final exactSwitch = tester.widget<SwitchListTile>(
-      find.ancestor(
-        of: find.text('Allow exact alarms'),
-        matching: find.byType(SwitchListTile),
-      ),
-    );
-    expect(exactSwitch.value, isTrue);
   });
 
   testWidgets('enables Resume only while a pause window is active', (

--- a/app/test/widget/thermostats_page_interaction_test.dart
+++ b/app/test/widget/thermostats_page_interaction_test.dart
@@ -110,7 +110,6 @@ Future<ThermostatDatabase> _pumpPage(
           (ref) => Stream.value(
             const AlertConfig(
               pollInterval: Duration(minutes: 5),
-              exactAlarmsEnabled: false,
               soundUri: null,
               vibrate: true,
               volumeBoost: false,

--- a/app/test/widget/thermostats_page_test.dart
+++ b/app/test/widget/thermostats_page_test.dart
@@ -12,7 +12,6 @@ import 'package:farmctl/features/thermostats/widgets/thermostat_card.dart';
 
 const _defaultConfig = AlertConfig(
   pollInterval: Duration(minutes: 5),
-  exactAlarmsEnabled: false,
   soundUri: null,
   vibrate: true,
   volumeBoost: false,
@@ -154,7 +153,6 @@ void main() {
       thermostats: Stream.value([_summary('t1', 'Greenhouse')]),
       config: AlertConfig(
         pollInterval: const Duration(minutes: 5),
-        exactAlarmsEnabled: false,
         soundUri: null,
         vibrate: true,
         volumeBoost: false,

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -10,7 +10,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 const _defaultConfig = AlertConfig(
   pollInterval: Duration(minutes: 5),
-  exactAlarmsEnabled: false,
   soundUri: null,
   vibrate: true,
   volumeBoost: false,


### PR DESCRIPTION
## Summary
- Background thermostat monitoring was unreliable on a Pixel 9 (Android 15/16): the previous dual-scheduler (WorkManager, 15-min floor + `android_alarm_manager_plus`, exact-alarm-permission-dependent) is Doze/App-Standby-deferrable.
- Replaces it with a real Android **Foreground Service** (`flutter_foreground_task`, `specialUse` type — no `dataSync` 6h/24h cap, no boot-launch restriction), which is exempt from Doze/App Standby while alive and drives every poll directly via `onRepeatEvent`, down to the user's configured 1–30 min interval with no platform floor and no exact-alarm permission.
- `android_alarm_manager_plus` and the exact-alarm feature (Settings toggle, permission flow, `AlertConfig.exactAlarmsEnabled`, DB column) are removed entirely — a live foreground service supersedes what they existed to work around.
- WorkManager is demoted to a **watchdog**: a fixed 15-minute periodic task that only restarts the foreground service if it isn't running (survives an OEM battery-manager killing the app process, which the plugin's own `allowAutoRestart`/`autoRunOnBoot` can't); it never runs the monitor itself, so there's a single source of truth for polling.
- `targetSdk` bumped 34 → 35 to match Android 15 and the foreground-service APIs used.
- DB migration v8 → v9 drops the now-unused `exact_alarms_enabled` column.

## Review
Two rounds of review were run against the real `flutter_foreground_task` v9.2.2 plugin source (not training-data assumptions): an initial scheduler-correctness + Android-platform pass, then a full 7-angle finder pass (line-by-line, removed-behavior, cross-file tracing, reuse, simplification, efficiency, altitude, conventions) plus a skeptic verification of the fixes. Confirmed issues fixed: a race between `onStart`/`onRepeatEvent` (closed with an in-isolate lock), duplicated `ForegroundTaskOptions` construction (extracted to a helper), a redundant `init()` call on the already-running path (removed, verified safe against plugin source), and stale comments/naming left over from the removed AlarmManager path. Full rationale for fixed/declined/refuted findings is in `.agent/ExecPlan-BackgroundReliability.md`.

## Test plan
- [x] `dart run build_runner build --delete-conflicting-outputs`
- [x] `flutter analyze` — clean
- [x] `flutter test` — 211/211 passing (including new migration and scheduling unit tests)
- [x] `dart format` — clean
- [x] Coverage 72.75% (CI threshold 70%)
- [ ] **Manual verification on a real Pixel 9** — not possible in this sandboxed session (no device/emulator access). Recommended before relying on this in production: grant "Allow background activity" in Settings, confirm the persistent notification survives 30+ min of screen-off, reboot, and a force-stop + wait for the 15-min watchdog to restart the service.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LghP1SiPYnLBuHTc98s75R)_